### PR TITLE
Add support for tracking expected failures across multiple invocations of the wrapper

### DIFF
--- a/SourceKitStressTester/Sources/Common/Message.swift
+++ b/SourceKitStressTester/Sources/Common/Message.swift
@@ -40,7 +40,7 @@ public enum SourceKitError: Error {
 }
 
 public enum SourceKitErrorReason: String, Codable {
-  case errorResponse, errorTypeInResponse, errorDeserializingSyntaxTree
+  case errorResponse, errorTypeInResponse, errorDeserializingSyntaxTree, sourceAndSyntaxTreeMismatch
 }
 
 public enum RequestInfo {
@@ -299,6 +299,8 @@ extension SourceKitErrorReason: CustomStringConvertible {
       return "SourceKit returned a response containing <<error type>>"
     case .errorDeserializingSyntaxTree:
       return "SourceKit returned a response with invalid SyntaxTree data"
+    case .sourceAndSyntaxTreeMismatch:
+      return "SourceKit returned a syntax tree that doesn't match the expected source"
     }
   }
 }

--- a/SourceKitStressTester/Sources/Common/Message.swift
+++ b/SourceKitStressTester/Sources/Common/Message.swift
@@ -37,6 +37,17 @@ public enum SourceKitError: Error {
   case crashed(request: RequestInfo)
   case timedOut(request: RequestInfo)
   case failed(_ reason: SourceKitErrorReason, request: RequestInfo, response: String)
+
+  public var request: RequestInfo {
+    switch self {
+    case .crashed(let request):
+      return request
+    case .timedOut(let request):
+      return request
+    case .failed(_, let request, _):
+      return request
+    }
+  }
 }
 
 public enum SourceKitErrorReason: String, Codable {

--- a/SourceKitStressTester/Sources/SwiftCWrapper/ExpectedFailure.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/ExpectedFailure.swift
@@ -1,0 +1,228 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Common
+
+struct ExpectedFailure: Equatable, Codable {
+  let applicableConfigs: Set<String>
+  let issueUrl: String
+  let path: String
+  let modification: String?
+  let request: Request
+
+  /// Checks if this expected failure matches the given request
+  ///
+  /// - parameters:
+  ///   - info: the request to match against
+  /// - returns: true if the request matches
+  func matches(_ info: RequestInfo) -> Bool {
+    switch info {
+    case .editorOpen(let document):
+      guard case .editorOpen = request else { return false }
+      return match(document.path, against: path) &&
+        match(document.modification?.summaryCode, against: modification)
+    case .editorClose(let document):
+      guard case .editorClose = request else { return false }
+      return match(document.path, against: path) &&
+        match(document.modification?.summaryCode, against: modification)
+    case .editorReplaceText(let document, let offset, let length, let text):
+      guard case .editorReplaceText(let spec) = request else { return false }
+      return match(document.path, against: path) &&
+        match(document.modification?.summaryCode, against: modification) &&
+        match(offset, against: spec.offset) &&
+        match(length, against: spec.length) &&
+        match(text, against: spec.text)
+    case .cursorInfo(let document, let offset, _):
+      guard case .cursorInfo(let specOffset) = request else { return false }
+      return match(document.path, against: path) &&
+        match(document.modification?.summaryCode, against: modification) &&
+        match(offset, against: specOffset)
+    case .codeComplete(let document, let offset, _):
+      guard case .codeComplete(let specOffset) = request else { return false }
+      return match(document.path, against: path) &&
+        match(document.modification?.summaryCode, against: modification) &&
+        match(offset, against: specOffset)
+    case .rangeInfo(let document, let offset, let length, _):
+      guard case .rangeInfo(let spec) = request else { return false }
+      return match(document.path, against: path) &&
+        match(document.modification?.summaryCode, against: modification) &&
+        match(offset, against: spec.offset) &&
+        match(length, against: spec.length)
+    case .semanticRefactoring(let document, let offset, let refactoring, _):
+      guard case .semanticRefactoring(let spec) = request else { return false }
+      return match(document.path, against: path) &&
+        match(document.modification?.summaryCode, against: modification) &&
+        match(offset, against: spec.offset) &&
+        match(refactoring, against: spec.refactoring)
+    }
+  }
+
+  /// Checks whether this expected failure could match a request made in the
+  /// given file path
+  func isApplicable(toPath path: String) -> Bool {
+    return match(path, against: self.path)
+  }
+
+  private func match<T: Equatable>(_ input: T?, against specification: T?) -> Bool {
+    guard let specification = specification else { return true }
+    guard let input = input else { return false }
+    return input == specification
+  }
+
+  private func match(_ input: String?, against specification: String?) -> Bool {
+    guard let specification = specification else { return true }
+    guard let input = input else { return false }
+    guard specification.contains("*") else { return input == specification }
+
+    let parts = specification.split(separator: "*")
+    guard !parts.isEmpty else { return true }
+
+    let anchoredStart = !specification.hasPrefix("*")
+    let anchoredEnd = !specification.hasSuffix("*")
+    var remaining = Substring(input)
+
+    for (offset, part) in parts.enumerated() {
+      guard let match = remaining.range(of: part, options: [.caseInsensitive]) else {
+        return false
+      }
+      if offset == 0 && anchoredStart && match.lowerBound != input.startIndex {
+        return false
+      }
+      if offset == parts.endIndex - 1 && anchoredEnd && match.upperBound != input.endIndex {
+        return false
+      }
+      remaining = remaining[match.upperBound...]
+    }
+    return true
+  }
+}
+
+extension ExpectedFailure {
+
+  init(matching requestInfo: RequestInfo, issueUrl: String, config: String) {
+    self.issueUrl = issueUrl
+    self.applicableConfigs = [config]
+
+    switch requestInfo {
+    case .editorOpen(let document):
+      path = document.path
+      modification = document.modification?.summaryCode
+      request = .editorOpen
+    case .editorClose(let document):
+      path = document.path
+      modification = document.modification?.summaryCode
+      request = .editorClose
+    case .editorReplaceText(let document, let offset, let length, let text):
+      path = document.path
+      modification = document.modification?.summaryCode
+      request = .editorReplaceText(offset: offset, length: length, text: text)
+    case .cursorInfo(let document, let offset, _):
+      path = document.path
+      modification = document.modification?.summaryCode
+      request = .cursorInfo(offset: offset)
+    case .codeComplete(let document, let offset, _):
+      path = document.path
+      modification = document.modification?.summaryCode
+      request = .codeComplete(offset: offset)
+    case .rangeInfo(let document, let offset, let length, _):
+      path = document.path
+      modification = document.modification?.summaryCode
+      request = .rangeInfo(offset: offset, length: length)
+    case .semanticRefactoring(let document, let offset, let refactoring, _):
+      path = document.path
+      modification = document.modification?.summaryCode
+      request = .semanticRefactoring(offset: offset, refactoring: refactoring)
+    }
+  }
+
+  enum Request: Equatable, Codable {
+    case editorOpen
+    case editorClose
+    case editorReplaceText(offset: Int?, length: Int?, text: String?)
+    case cursorInfo(offset: Int?)
+    case codeComplete(offset: Int?)
+    case rangeInfo(offset: Int?, length: Int?)
+    case semanticRefactoring(offset: Int?, refactoring: String?)
+
+    init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      switch try container.decode(RequestBase.self, forKey: .kind) {
+      case .editorOpen:
+        self = .editorOpen
+      case .editorClose:
+        self = .editorClose
+      case .editorReplaceText:
+        self = .editorReplaceText(
+          offset: try container.decodeIfPresent(Int.self, forKey: .offset),
+          length: try container.decodeIfPresent(Int.self, forKey: .length),
+          text: try container.decodeIfPresent(String.self, forKey: .text)
+        )
+      case .cursorInfo:
+        self = .cursorInfo(
+          offset: try container.decodeIfPresent(Int.self, forKey: .offset)
+        )
+      case .codeComplete:
+        self = .codeComplete(
+          offset: try container.decodeIfPresent(Int.self, forKey: .offset)
+        )
+      case .rangeInfo:
+        self = .rangeInfo(
+          offset: try container.decodeIfPresent(Int.self, forKey: .offset),
+          length: try container.decodeIfPresent(Int.self, forKey: .length)
+        )
+      case .semanticRefactoring:
+        self = .semanticRefactoring(
+          offset: try container.decodeIfPresent(Int.self, forKey: .offset),
+          refactoring: try container.decodeIfPresent(String.self, forKey: .refactoring)
+        )
+      }
+    }
+
+    func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      switch self {
+      case .editorOpen:
+        try container.encode(RequestBase.editorOpen, forKey: .kind)
+      case .editorClose:
+        try container.encode(RequestBase.editorClose, forKey: .kind)
+      case .editorReplaceText(let offset, let length, let text):
+        try container.encode(RequestBase.editorReplaceText, forKey: .kind)
+        try container.encode(offset, forKey: .offset)
+        try container.encode(length, forKey: .length)
+        try container.encode(text, forKey: .text)
+      case .cursorInfo(let offset):
+        try container.encode(RequestBase.cursorInfo, forKey: .kind)
+        try container.encode(offset, forKey: .offset)
+      case .codeComplete(let offset):
+        try container.encode(RequestBase.codeComplete, forKey: .kind)
+        try container.encode(offset, forKey: .offset)
+      case .rangeInfo(let offset, let length):
+        try container.encode(RequestBase.rangeInfo, forKey: .kind)
+        try container.encode(offset, forKey: .offset)
+        try container.encode(length, forKey: .length)
+      case .semanticRefactoring(let offset, let refactoring):
+        try container.encode(RequestBase.semanticRefactoring, forKey: .kind)
+        try container.encode(offset, forKey: .offset)
+        try container.encode(refactoring, forKey: .refactoring)
+      }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case kind, offset, length, text, refactoring
+    }
+
+    private enum RequestBase: String, Codable {
+      case editorOpen, editorClose, editorReplaceText
+      case cursorInfo, codeComplete, rangeInfo, semanticRefactoring
+    }
+  }
+}

--- a/SourceKitStressTester/Sources/SwiftCWrapper/FailureManager.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/FailureManager.swift
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Common
+import Foundation
+
+/// Keeps track of the detected failures and their status (expected/unexpected)
+/// across multiple wrapper invocations
+struct FailureManager {
+  let activeConfig: String
+  let expectedFailuresFile: URL
+  let resultsFile: URL
+  let encoder: JSONEncoder
+
+  /// - parameters:
+  ///   - expectedFailuresFile: the URL of a JSON file describing the
+  ///   expected failures
+  ///   - resultsFile: the URL of the file to use to store failures across
+  ///   multiple invocations
+  init(activeConfig: String, expectedFailuresFile: URL, resultsFile: URL) {
+    self.activeConfig = activeConfig
+    self.expectedFailuresFile = expectedFailuresFile
+    self.resultsFile = resultsFile
+    self.encoder = JSONEncoder()
+    encoder.outputFormatting = .prettyPrinted
+  }
+
+  /// Updates this instance's backing resultsFile to account for the files
+  /// processed by this invocation of the wrapper, and the error it detected,
+  /// if any.
+  ///
+  /// - parameters:
+  ///   - for: the set of files processed
+  ///   - error: the detected error, if any
+  func update(for files: Set<String>, error: SourceKitError?) throws -> ExpectedFailure? {
+    let failureSpecs = try getFailureSpecifications(applicableTo: files)
+    var state = try getCurrentState()
+    let matchingSpec = state.add(processedFiles: files, error: error, specs: failureSpecs)
+    let data = try encoder.encode(state)
+    FileManager.default.createFile(atPath: resultsFile.path, contents: data)
+    return matchingSpec
+  }
+
+  private func getFailureSpecifications(applicableTo files: Set<String>) throws -> [ExpectedFailure] {
+    let data = try Data(contentsOf: expectedFailuresFile)
+    return try JSONDecoder().decode([ExpectedFailure].self, from: data)
+      .filter { spec in
+        spec.applicableConfigs.contains(activeConfig) &&
+          files.contains { spec.isApplicable(toPath: $0) }
+    }
+  }
+
+  private func getCurrentState() throws -> FailureManagerState {
+    guard FileManager.default.fileExists(atPath: resultsFile.path) else {
+      return FailureManagerState()
+    }
+    let data = try Data(contentsOf: resultsFile)
+    return try JSONDecoder().decode(FailureManagerState.self, from: data)
+  }
+}
+
+/// Holds the state of the FailureManager that will be serialized across
+/// invocations
+fileprivate struct FailureManagerState: Codable {
+  var processedFiles = Set<String>()
+  var expectedFailures = Dictionary<String, [SourceKitError]>()
+  var failures = [SourceKitError]()
+  var unmatchedExpectedFailures = [ExpectedFailure]()
+
+  /// Updates the state to account for the given set of files covered during
+  /// this invocation of the wrapper, and the first error detected, if any.
+  ///
+  /// - returns: the expected failure that matches the given error, if any
+  mutating func add(processedFiles: Set<String>, error: SourceKitError?, specs: [ExpectedFailure]) -> ExpectedFailure? {
+    var result: ExpectedFailure? = nil
+    let added = processedFiles.subtracting(self.processedFiles)
+    unmatchedExpectedFailures.append(contentsOf: specs.filter { spec in
+      added.contains {spec.isApplicable(toPath: $0)}
+    })
+    self.processedFiles.formUnion(processedFiles)
+    if let error = error {
+      if let match = specs.first(where: {$0.matches(error.request)}) {
+        expectedFailures[match.issueUrl] = (expectedFailures[match.issueUrl] ?? []) + [error]
+        unmatchedExpectedFailures.removeAll(where: {$0 == match})
+        result = match
+      } else {
+        failures.append(error)
+      }
+    }
+    return result
+  }
+}
+
+extension DocumentModification {
+  /// A String with enough information to unique identify the modified state of
+  /// a document in comparison to other modifications produced by the stress
+  /// tester.
+  var summaryCode: String {
+    return "\(mode)-\(content.count)"
+  }
+}

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -21,16 +21,16 @@ struct SwiftCWrapper {
   let stressTesterPath: String
   let astBuildLimit: Int?
   let ignoreFailures: Bool
-  let machineReadable: Bool
+  let failureManager: FailureManager?
   let failFast: Bool
 
-  init(swiftcArgs: [String], swiftcPath: String, stressTesterPath: String, astBuildLimit: Int?, ignoreFailures: Bool, machineReadable: Bool, failFast: Bool) {
+  init(swiftcArgs: [String], swiftcPath: String, stressTesterPath: String, astBuildLimit: Int?, ignoreFailures: Bool, failureManager: FailureManager?, failFast: Bool) {
     self.arguments = swiftcArgs
     self.swiftcPath = swiftcPath
     self.stressTesterPath = stressTesterPath
     self.astBuildLimit = astBuildLimit
     self.ignoreFailures = ignoreFailures
-    self.machineReadable = machineReadable
+    self.failureManager = failureManager
     self.failFast = failFast
   }
 
@@ -43,7 +43,7 @@ struct SwiftCWrapper {
       .sorted()
   }
 
-  func run() -> Int32 {
+  func run() throws -> Int32 {
     // Execute the compiler
     let swiftcResult = ProcessRunner(launchPath: swiftcPath, arguments: arguments).run(capturingOutput: false)
     guard swiftcResult.status == EXIT_SUCCESS else { return swiftcResult.status }
@@ -78,67 +78,57 @@ struct SwiftCWrapper {
     stderrStream <<< "\n"
     stderrStream.flush()
 
+    // Report the overall runtime
     let elapsedSeconds = -startTime.timeIntervalSinceNow
-    stderrStream <<< "Runtime: \(elapsedSeconds.formatted() ?? String(elapsedSeconds))\n"
+    stderrStream <<< "Runtime: \(elapsedSeconds.formatted() ?? String(elapsedSeconds))\n\n"
     stderrStream.flush()
 
-    // Report the list of processed files and the first failure (if any)
-    var result = WrapperResult()
-    for operation in operations where result.error == nil {
+    // Determine the set of processed files and the first failure (if any)
+    var processedFiles = Set<String>()
+    var detectedError: SourceKitError? = nil
+    for operation in operations where detectedError == nil {
       switch operation.status {
       case .cancelled:
         fatalError("cancelled operation before failed operation")
       case .unexecuted:
         fatalError("unterminated operation")
       case .failed(let error):
-        result.error = error
+        detectedError = error
         fallthrough
       case .passed:
-        result.processedFiles.insert(operation.file)
+        processedFiles.insert(operation.file)
       }
     }
 
-    if machineReadable {
-      let data = try! JSONEncoder().encode(result)
-      stderrStream <<< "[stress-tester]" <<< data <<< "\n"
-      if let error = result.error {
-        stderrStream <<< String(describing: error) <<< "\n"
-      }
-    } else {
-      stderrStream <<< String(describing: result) <<< "\n"
-    }
-    stderrStream.flush()
+    let matchingSpec = try failureManager?.update(for: processedFiles, error: detectedError)
+    try report(detectedError, matching: matchingSpec)
 
-    if result.passed {
+    if detectedError == nil || matchingSpec != nil {
       return EXIT_SUCCESS
     }
     return ignoreFailures ? swiftcResult.status : EXIT_FAILURE
   }
-}
 
-struct WrapperResult: Codable, CustomStringConvertible {
-  var processedFiles: Set<String> = []
-  var error: SourceKitError? = nil
+  private func report(_ error: SourceKitError?, matching xfail: ExpectedFailure? = nil) throws {
+    defer { stderrStream.flush() }
 
-  var passed: Bool {
-    return error == nil
-  }
-
-  var description: String {
-    var output = ""
-    if !processedFiles.isEmpty {
-      output += """
-        Processed files:
-          \(processedFiles.sorted().joined(separator: "\n  "))\n
-        """
+    guard let error = error else {
+      stderrStream <<< "No failures detected.\n"
+      return
     }
-    if let error = error {
-      output += "Detected failure: \(error)\n"
+
+    if let xfail = xfail {
+      stderrStream <<< "Detected expected failure [\(xfail.issueUrl)]: \(error)\n\n"
     } else {
-      output += "No failures detected."
+      stderrStream <<< "Detected unexpected failure: \(error)\n\n"
+      if let failureManager = failureManager {
+        let xfail = ExpectedFailure(matching: error.request, issueUrl: "<issue url>",
+                                    config: failureManager.activeConfig)
+        let json = try failureManager.encoder.encode(xfail)
+        stderrStream <<< "Add the following entry to the expected failures JSON file to mark it as expected:\n"
+        stderrStream <<< json <<< "\n\n"
+      }
     }
-
-    return output
   }
 }
 

--- a/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
+++ b/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
@@ -12,6 +12,7 @@
 
 import XCTest
 @testable import SwiftCWrapper
+import Common
 
 class SwiftCWrapperToolTests: XCTestCase {
   var workspace: URL!
@@ -96,6 +97,24 @@ class SwiftCWrapperToolTests: XCTestCase {
     XCTAssertTrue(!second.isCancelled)
     XCTAssertTrue(third.isCancelled)
     XCTAssertTrue(fourth.isCancelled)
+  }
+
+  func testFailureManager() {
+    let xfail = ExpectedFailure(
+      applicableConfigs: ["master"], issueUrl: "<issue-url>",
+      path: "*/foo/bar.swift", modification: nil,
+      request: .editorReplaceText(offset: 42, length: 0, text: nil)
+    )
+
+    let document1 = DocumentInfo(path: "/baz/foo/bar.swift", modification: nil)
+    let failure1 = RequestInfo.editorReplaceText(document: document1, offset: 42, length: 0, text: ".")
+    let failure2 = RequestInfo.editorReplaceText(document: document1, offset: 42, length: 2, text: "hello")
+    let document2 = DocumentInfo(path: "/baz/bar.swift", modification: nil)
+    let failure3 = RequestInfo.editorReplaceText(document: document2, offset: 42, length: 0, text: ".")
+
+    XCTAssertTrue(xfail.matches(failure1))
+    XCTAssertFalse(xfail.matches(failure2))
+    XCTAssertFalse(xfail.matches(failure3))
   }
 
   override func setUp() {


### PR DESCRIPTION
Also adds an additional check in the stress tester that the syntax tree (which is updated incrementally after each editorReplaceText request) stays in sync with the expected state of the source.