### PR TITLE
Update SyntaxVisitor overrides to match recent changes in SwiftSyntax

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -125,8 +125,9 @@ final class RequestActionGenerator: SyntaxVisitor, ActionGenerator {
     return actions
   }
 
-  override func visit(_ token: TokenSyntax) {
+  override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     actions.append(contentsOf: generateActions(for: token, withReplaceTexts: false))
+    return .visitChildren
   }
 }
 
@@ -142,8 +143,9 @@ final class RewriteActionGenerator: SyntaxVisitor, ActionGenerator {
     return actions
   }
 
-  override func visit(_ token: TokenSyntax) {
+  override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     actions.append(contentsOf: generateActions(for: token, withReplaceTexts: true))
+    return .visitChildren
   }
 }
 
@@ -252,9 +254,10 @@ fileprivate final class TokenData: SyntaxVisitor {
     depth -= 1
   }
 
-  override func visit(_ token: TokenSyntax) {
+  override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     tokens.append(token)
     depths[token] = depth
+    return .visitChildren
   }
 }
 


### PR DESCRIPTION
The visit methods now return whether to walk into children or not as of https://github.com/apple/swift-syntax/pull/35