### PR TITLE
Increase request timeout and filter out Swift files under /submodules/

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -213,7 +213,7 @@ struct SourceKitDocument {
       response = $0
       completed.signal()
     }
-    switch completed.wait(timeout: .now() + DispatchTimeInterval.seconds(60)) {
+    switch completed.wait(timeout: .now() + DispatchTimeInterval.seconds(300)) {
     case .success:
       return response!
     case .timedOut:

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -145,7 +145,8 @@ struct SwiftFile: Comparable {
   }
 
   var isProjectFile: Bool {
-    let dependencyPaths = ["/.build/checkouts/", "/Pods/", "/Carthage/Checkouts"]
+    // TODO: make this configurable
+    let dependencyPaths = ["/.build/checkouts/", "/Pods/", "/Carthage/Checkouts", "/submodules/"]
     return dependencyPaths.allSatisfy {!file.path.contains($0)}
   }
 


### PR DESCRIPTION
The timeout is intended to handle hangs, rather than slow requests, so bump it
up. Also filter out file paths under /submodules/ as, at least for the Swift
source compatibility suite, this seems to be used for checkouts of dependent
projects rather than source of the project being stress tested itself. Having
these paths hard coded is non-ideal, so added a todo to make them configurable.