### PR TITLE
Switch ProcessRunner.run() to use readDataToEndOfFile()

### DIFF
--- a/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
@@ -83,7 +83,6 @@ final class StressTestOperation: Operation {
           status: \(status)
           args: \(process.process.arguments?.joined(separator: " ") ?? "")
           stdout: \(String(data: result.stdout, encoding: .utf8) ?? "")
-          stderr: \(String(data: result.stderr, encoding: .utf8) ?? "")
         """)
     }
   }


### PR DESCRIPTION
Rather than using readabilityHandler for capturing output.