### PR TITLE
Share build-script-helper between both tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,59 @@ This project aims to provide stress testing utilities to help find reproducible 
 
 ## Current tools
 
-| Tool      | Description |
-| --------- | ----------- |
-[sk&#8209;stress&#8209;test](SourceKitStressTester/README.md) | a utility for exercising a range of SourceKit functionality, such as code completion and local refactorings, at all applicable locations in a set of Swift source files.
-[swift&#8209;evolve](SwiftEvolve/README.md) | a utility to randomly modify Swift source files in ways libraries are permitted to evolve without breaking ABI compatibility.
+| Tool      | Description | build-script Flag | Package Name |
+| --------- | ----------- | ----------------- | ----------------- |
+[sk&#8209;stress&#8209;test](SourceKitStressTester/README.md) | a utility for exercising a range of SourceKit functionality, such as code completion and local refactorings, at all applicable locations in a set of Swift source files. | `--skstresstester` | SourceKitStressTester |
+[swift&#8209;evolve](SwiftEvolve/README.md) | a utility to randomly modify Swift source files in ways libraries are permitted to evolve without breaking ABI compatibility. | `--swiftevolve` | SwiftEvolve |
+
+## Building
+
+The tools in this repository can be built in several different ways:
+
+### Using Swift's build-script
+
+If you want to build the tools to use a locally built sourcekitd and SwiftLang, use the Swift repository's build-script to build and test the stress tester by passing `--swiftsyntax` and the desired tools' flags as extra options. To build and run tests, for example, you would run:
+
+```
+$ ./utils/build-script -t --swiftsyntax --skstresstester
+```
+
+### For local development
+
+For local development you'll need to have the [Swift](https://github.com/apple/swift) and [SwiftSyntax](https://github.com/apple/swift-syntax) repositories checked out adjacent to the swift-stress-tester repository in the structure shown below:
+```
+<workspace>/
+swift/
+swift-syntax/
+swift-stress-tester/
+```
+If you installed the Swift 5.0 development toolchain be sure to check out `swift-5.0-branch`, rather than `master` in all of these repositories before continuing with the instructions below.
+
+### Via Xcode
+
+To generate an Xcode project that's set up correctly, run `build-script-helper.py`, passing the path to the swiftc executable in the downloaded toolchain via the `--swiftc-exec` option, the tool's package name in the `--package-dir` option, and the `generate-xcodeproj` action:
+```
+$ ./build-script-helper.py --package-dir SourceKitStressTester --swiftc-exec $TOOLCHAIN_DIR/usr/bin/swiftc generate-xcodeproj
+```
+This will generate `SourceKitStressTester/SourceKitStressTester.xcodeproj`. Open it and select the toolchain you installed from the Xcode > Toolchains menu, before building the `SourceKitStressTester-Package` scheme.
+
+### Via command line
+
+To build, run `build-script-helper.py`, passing the path to the swiftc executable in the downloaded toolchain via the `--swiftc-exec` option and the tool's package name in the `--package-dir` option:
+```
+$ ./build-script-helper.py --package-dir SourceKitStressTester --swiftc-exec $TOOLCHAIN_DIR/usr/bin/swiftc
+```
+
+To run the tests, repeat the above command, but additionally pass the `test` action:
+```
+$ ./Utilities/build-script-helper.py --package-dir SourceKitStressTester --swiftc-exec $TOOLCHAIN_DIR/usr/bin/swiftc test
+```
+
+## Running
+
+Building will create either one or two executables, depending on the package you build. These will be in the package directory's `.build/debug` sudbirectory if building on the command line or via the Swift repo's build-script, and under `Products/Debug` in the Xcode project's `DerivedData` directory if building there. They are also available in the `usr/bin` directory of recent trunk and swift 5.0 development toolchains from swift.org, if you're just interested in running them, rather than building them locally.
+
+See the individual packages' README files for information about how to run and use their executables.
 
 ## License
 

--- a/SourceKitStressTester/README.md
+++ b/SourceKitStressTester/README.md
@@ -5,49 +5,7 @@ The Sourcekitd stress tester is a utility for running a range of sourcekitd requ
 
 ## Building
 
-The sourcekitd stress tester relies on the SwiftLang library, which isn't included in Xcode's default toolchain, so make sure you have a recent trunk or Swift 5.0 development toolchain installed from [swift.org](https://swift.org/download/). 
-
-Also take note of where the toolchain you installed is located. Depending on the options you chose this should be under Library/Developer/Toolchains/<downloaded-toolchain> in either you home or root directory, e.g:
-```
-$ TOOLCHAIN_DIR=/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2018-11-26-a.xctoolchain
-```
-
-### Workspace setup
-For local development you'll need to have the [Swift](https://github.com/apple/swift) and [SwiftSyntax](https://github.com/apple/swift-syntax) repositories checked out adjacent to the swift-stress-tester repository in the structure shown below:
-```
-<workspace>/
-  swift/
-  swift-syntax/
-  swift-stress-tester/
-```
-If you installed the Swift 5.0 development toolchain be sure to check out `swift-5.0-branch`, rather than `master` in all of these repositories before continuing with the instructions below.
-
-### Via Xcode
-
-To generate an Xcode project that's set up correctly, run `build-script-helper.py` in the Utilities directory, passing the path to the swiftc executable in the downloaded toolchain via the `--swiftc-exec` option and the `generate-xcodeproj` action:
-```
-$ ./Utilities/build-script-helper.py --swiftc-exec $TOOLCHAIN_DIR/usr/bin/swiftc generate-xcodeproj
-```
-This will generate `SourceKitStressTester.xcodeproj`. Open it and select the toolchain you installed from the Xcode > Toolchains menu, before building the `SourceKitStressTester-Package` scheme.
-
-### Via command line
-
-To build, run `build-script-helper.py` in the Utilities directory, passing the path to the swiftc executable in the downloaded toolchain via the `--swiftc-exec` option:
-```
-$ ./Utilities/build-script-helper.py --swiftc-exec $TOOLCHAIN_DIR/usr/bin/swiftc
-```
-
-To run the tests, repeat the above command, but additionally pass the `test` action:
-```
-$ ./Utilities/build-script-helper.py --swiftc-exec $TOOLCHAIN_DIR/usr/bin/swiftc test
-```
-
-### Via swift's build script
-
-If you want to build the stress tester to use a locally built sourcekitd and SwiftLang, use the Swift repository's build-script to build and test the stress tester by passing `--swiftsyntax` and `--skstresstester` as extra options. To build and run tests, for example, you would run:
-```
-$ ./utils/build-script -t --swiftsyntax --skstresstester
-```
+You can build SourceKitStressTester using Swift's build-script, using the command line, or using Xcode. In the latter two cases, you'll use the build-script-helper.py script in the parent directory. Please see [the README file adjacent to it](../README.md) for full instructions.
 
 ## Running
 

--- a/SourceKitStressTester/Utilities/build-script-helper.py
+++ b/SourceKitStressTester/Utilities/build-script-helper.py
@@ -2,245 +2,61 @@
 
 """
   This source file is part of the Swift.org open source project
- 
-  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+
+  Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
   Licensed under Apache License v2.0 with Runtime Library Exception
 
   See https://swift.org/LICENSE.txt for license information
   See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
- ------------------------------------------------------------------------------
- This is a helper script for the main swift repository's build-script.py that
- knows how to build and install the stress tester utilities given a swift
- workspace.
+  ------------------------------------------------------------------------------
+  This is a wrapper around the relocated build-script-helper.py (now at
+  ../../build-script-helper.py) which allows it to be used by old versions of
+  the main swift repo's build-script.py.
 
+  It has been left here to ease the transition to the new helper script; it
+  should eventually be removed.
 """
 
 from __future__ import print_function
 
-import argparse
-import sys
 import os
-import subprocess
-
-PACKAGE_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-
 
 def main():
-  args = parse_args(sys.argv[1:])
-  run(args)
+  print("(Using swift-stress-tester build compatibility shim...)")
+  impl_script = ImplScript(__file__)
+  impl_main = impl_script.get_local('main')
+  impl_main(['--package-dir', impl_script.package_dir])
 
+class ImplScript(object):
+  def __init__(self, file_path):
+    # if file_path = <base>/<package>/<ignored>/<scriptname>, then sets...
+    #
+    # Local variables:
+    #
+    #   script_name = <scriptname>
+    #   utilities_path = <base>/<package>/<ignored> (temporary)
+    #   repo_path = <base> (temporary)
+    #   impl_path = <base>/<scriptname>
+    #
+    # Attributes:
+    #
+    #   self.package_dir = <package>
+    #   self.locals = locals after performing exec(impl_path)
 
-def parse_args(args):
-  parser = argparse.ArgumentParser(prog='BUILD-SCRIPT-HELPER.PY')
+    utilities_path, script_name = os.path.split(file_path)
+    repo_path, self.package_dir = os.path.split(os.path.dirname(utilities_path))
+    impl_path = os.path.join(repo_path, script_name)
 
-  parser.add_argument('-v', '--verbose', action='store_true', help='log executed commands')
-  parser.add_argument('--prefix', help='install path')
-  parser.add_argument('--config', default='release')
-  parser.add_argument('--build-dir', default=os.path.join(PACKAGE_DIR, '.build'))
-  parser.add_argument('--swiftc-exec', help='the compiler to use when building this package (default: xcrun -f swiftc)')
-  parser.add_argument('--swift-build-exec', help='the swift-build exec to use to build this package (default: xcrun -f swift-build)')
-  parser.add_argument('--swift-test-exec', help='the swift-test exec to use to test this package (default: xcrun -f swift-test)')
-  parser.add_argument('--swift-package-exec', help='the swift-package exec to use to generate an xcode project for this package (default: xcrun -f swift-package)')
-  parser.add_argument('--sourcekitd-dir', help='the directory containing the sourcekitd.framework to use (default: relative to swiftc-exec)')
-  parser.add_argument('--swiftsyntax-dir', help='the directory containing SwiftSyntax\'s build products (libSwiftSyntax.dylib, and SwiftSyntax.swiftmodule)')
-  parser.add_argument('build_actions', help="Extra actions to perform. Can be any number of the following: [all, test, install, generate-xcodeproj]", nargs="*", default=[])
+    self.locals = dict(
+                      __file__=impl_path,
+                      __name__='__exec__',
+                      __package__=None
+                      )
+    exec(open(impl_path).read(), self.locals)
 
-  parsed = parser.parse_args(args)
-
-  if ("install" in parsed.build_actions or "all" in parsed.build_actions) and not parsed.prefix:
-    ArgumentParser.error("'--prefix' is required with the install action")
-  if parsed.swiftc_exec is None:
-    parsed.swiftc_exec = find_executable('swiftc')
-  if parsed.swift_build_exec is None:
-    parsed.swift_build_exec = find_executable('swift-build')
-  if parsed.swift_test_exec is None:
-    parsed.swift_test_exec = find_executable('swift-test')
-  if parsed.swift_package_exec is None:
-    parsed.swift_package_exec = find_executable('swift-package')
-  if parsed.sourcekitd_dir is None:
-    parsed.sourcekitd_dir = os.path.join(os.path.dirname(os.path.dirname(parsed.swiftc_exec)), 'lib')
-
-  return parsed
-
-
-def run(args):
-  if args.swiftsyntax_dir is None:
-    print("** Building SwiftSyntax **")
-    swiftsyntax_build_dir = os.path.join(PACKAGE_DIR, '.swiftsyntax_build')
-    build_swiftsyntax(swift_build_exec=args.swift_build_exec,
-      swiftc_exec=args.swiftc_exec,
-      build_dir=swiftsyntax_build_dir,
-      config=args.config,
-      verbose=args.verbose)
-    args.swiftsyntax_dir = os.path.join(swiftsyntax_build_dir, args.config)
-
-  sourcekit_searchpath=args.sourcekitd_dir
-  swiftsyntax_searchpath=args.swiftsyntax_dir
-
-  print("** Building Swift Stress Tester **")
-  build_package(swift_build_exec=args.swift_build_exec,
-    swiftc_exec=args.swiftc_exec,
-    sourcekit_searchpath=sourcekit_searchpath,
-    swiftsyntax_searchpath=swiftsyntax_searchpath,
-    build_dir=args.build_dir,
-    config=args.config,
-    verbose=args.verbose)
-
-  output_dir = os.path.realpath(os.path.join(args.build_dir, args.config))
-
-  if "generate-xcodeproj" in args.build_actions or "all" in args.build_actions:
-    print("** Generating Xcode project for Swift Stress Tester")
-    generate_xcodeproj(swift_package_exec=args.swift_package_exec,
-      sourcekit_searchpath=sourcekit_searchpath,
-      swiftsyntax_searchpath=swiftsyntax_searchpath,
-      verbose=args.verbose)
-
-  if "test" in args.build_actions or "all" in args.build_actions:
-    print("** Testing Swift Stress Tester **")
-    build_package(swift_build_exec=args.swift_test_exec,
-    swiftc_exec=args.swiftc_exec,
-    sourcekit_searchpath=sourcekit_searchpath,
-    swiftsyntax_searchpath=swiftsyntax_searchpath,
-    # note: test uses a different build_dir so it doesn't interfere with the 'build' step's products before install
-    build_dir=os.path.join(args.build_dir, 'test-build'),
-    config='debug',
-    verbose=args.verbose)
-
-  if "install" in args.build_actions or "all" in args.build_actions:
-    print("** Installing Swift Stress Tester **")
-    stdlib_dir = os.path.join(os.path.dirname(os.path.dirname(args.swiftc_exec)), 'lib', 'swift', 'macosx')
-    install_package(install_dir=args.prefix,
-      sourcekit_searchpath=sourcekit_searchpath,
-      swiftsyntax_searchpath=swiftsyntax_searchpath,
-      build_dir=output_dir,
-      rpaths_to_delete=[stdlib_dir],
-      verbose=args.verbose)
-
-
-def build_package(swift_build_exec, swiftc_exec, sourcekit_searchpath, swiftsyntax_searchpath, build_dir, config='release', verbose=False):
-  env = dict(os.environ)
-  env['SWIFT_EXEC'] = swiftc_exec
-
-  swiftc_args = ['-lSwiftSyntax', '-I', swiftsyntax_searchpath, '-L', swiftsyntax_searchpath, '-Fsystem', sourcekit_searchpath]
-  linker_args = ['-rpath', swiftsyntax_searchpath, '-rpath', sourcekit_searchpath]
-  args = [swift_build_exec, '--package-path', PACKAGE_DIR, '-c', config, '--build-path', build_dir] + interleave('-Xswiftc', swiftc_args) + interleave('-Xlinker', linker_args)
-  check_call(args, env=env, verbose=verbose)
-
-
-def install_package(install_dir, sourcekit_searchpath, swiftsyntax_searchpath, build_dir, rpaths_to_delete=[], verbose=False):
-  bin_dir = os.path.join(install_dir, 'bin')
-  lib_dir = os.path.join(install_dir, 'lib', 'swift', 'macosx')
-
-  for directory in [bin_dir, lib_dir]:
-    if not os.path.exists(directory):
-      os.makedirs(directory)
-
-  # Install sk-stress-test and sk-swiftc-wrapper
-  wrapper_src = os.path.join(build_dir, 'sk-swiftc-wrapper')
-  wrapper_dest = os.path.join(bin_dir, 'sk-swiftc-wrapper')
-  stress_tester_src = os.path.join(build_dir, 'sk-stress-test')
-  stress_tester_dest = os.path.join(bin_dir, 'sk-stress-test')
-  rpaths_to_delete += [sourcekit_searchpath, swiftsyntax_searchpath]
-  rpaths_to_add = ['@executable_path/../lib/swift/macosx', '@executable_path/../lib']
-  swiftsyntax_src = os.path.join(swiftsyntax_searchpath, 'libSwiftSyntax.dylib')
-  loadpath_changes = {os.path.realpath(swiftsyntax_src): '@rpath/libswiftSwiftSyntax.dylib'}
-
-  install(wrapper_src, wrapper_dest,
-    rpaths_to_delete=rpaths_to_delete,
-    rpaths_to_add=rpaths_to_add,
-    loadpath_changes=loadpath_changes,
-    verbose=verbose)
-  install(stress_tester_src, stress_tester_dest,
-    rpaths_to_delete=rpaths_to_delete,
-    rpaths_to_add=rpaths_to_add,
-    loadpath_changes=loadpath_changes,
-    verbose=verbose)
-
-
-def install(src, dest, rpaths_to_delete=[], rpaths_to_add=[], loadpath_changes={}, dylib_id=None, verbose=False):
-  copy_cmd=['rsync', '-a', src, dest]
-  print('installing %s to %s' % (os.path.basename(src), dest))
-  check_call(copy_cmd, verbose=verbose)
-
-  if dylib_id is not None:
-    check_call(['install_name_tool', '-id', dylib_id, dest], verbose=verbose)
-
-  for rpath in rpaths_to_delete:
-    remove_rpath(dest, rpath, verbose=verbose)
-  for rpath in rpaths_to_add:
-    add_rpath(dest, rpath, verbose=verbose)
-
-  for key, value in loadpath_changes.iteritems():
-    check_call(['install_name_tool', '-change', key, value, dest], verbose=verbose)
-
-
-def build_swiftsyntax(swift_build_exec, swiftc_exec, build_dir, config='release', verbose=False):
-  workspace = os.path.dirname(os.path.dirname(PACKAGE_DIR))
-  cmd = [os.path.join(workspace, 'swift-syntax', 'build-script.py'),
-    '--build-dir', os.path.join(PACKAGE_DIR, '.swiftsyntax_build'),
-    '--swiftc-exec', swiftc_exec,
-    '--swift-build-exec', swift_build_exec]
-
-  if config == 'release':
-    cmd += ['--release']
-
-  env = dict(os.environ)
-  check_call(cmd, env=env, verbose=verbose)
-
-
-def generate_xcodeproj(swift_package_exec, sourcekit_searchpath, swiftsyntax_searchpath, verbose=False):
-  config_path = os.path.join(PACKAGE_DIR, 'Config.xcconfig')
-  with open(config_path, 'w') as config_file:
-    config_file.write('''
-      SWIFT_INCLUDE_PATHS = {swiftsyntax_searchpath} $(inherited)
-      SYSTEM_FRAMEWORK_SEARCH_PATHS = {sourcekit_searchpath} $(inherited)
-      LIBRARY_SEARCH_PATHS = {swiftsyntax_searchpath} $(inherited)
-      LD_RUNPATH_SEARCH_PATHS = {sourcekit_searchpath} {swiftsyntax_searchpath} $(inherited)
-    '''.format(sourcekit_searchpath=sourcekit_searchpath, swiftsyntax_searchpath=swiftsyntax_searchpath))
-
-  env = dict(os.environ)
-  args = [swift_package_exec, 'generate-xcodeproj', '--xcconfig-overrides', config_path, '--output', os.path.join(PACKAGE_DIR, 'SourceKitStressTester.xcodeproj')]
-  check_call(args, env=env, verbose=verbose)
-
-def add_rpath(binary, rpath, verbose=False):
-  cmd = ['install_name_tool', '-add_rpath', rpath, binary]
-  check_call(cmd, verbose=verbose)
-
-
-def remove_rpath(binary, rpath, verbose=False):
-  cmd = ['install_name_tool', '-delete_rpath', rpath, binary]
-  check_call(cmd, verbose=verbose)
-
-
-def check_output(cmd, env=os.environ, verbose=False, **kwargs):
-  if verbose:
-    print(' '.join([escape_cmd_arg(arg) for arg in cmd]))
-  return subprocess.check_output(cmd, env=env, stderr=subprocess.STDOUT, **kwargs)
-
-
-def check_call(cmd, env=os.environ, verbose=False, **kwargs):
-  if verbose:
-    print(' '.join([escape_cmd_arg(arg) for arg in cmd]))
-  return subprocess.check_call(cmd, env=env, stderr=subprocess.STDOUT, **kwargs)
-
-
-def interleave(value, list):
-    return [item for pair in zip([value] * len(list), list) for item in pair]
-
-
-def find_executable(executable, toolchain=None):
-  if os.path.isfile(executable) and os.access(executable, os.X_OK):
-      return executable
-  extra_args = ['--toolchain', toolchain] if toolchain else []
-  return check_output(['xcrun', '-f', executable] + extra_args).rstrip()
-
-
-def escape_cmd_arg(arg):
-  if '"' in arg or ' ' in arg:
-    return '"%s"' % arg.replace('"', '\\"')
-  else:
-    return arg
+  def get_local(self, name):
+    return self.locals[name]
 
 if __name__ == '__main__':
   main()

--- a/SwiftEvolve/Package.swift
+++ b/SwiftEvolve/Package.swift
@@ -10,8 +10,7 @@ let package = Package(
         .library(name: "SwiftEvolve", targets: ["SwiftEvolve"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.2.0"),
-        .package(path: "../../swift-syntax"),
+        .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.2.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -21,7 +20,7 @@ let package = Package(
             dependencies: ["SwiftEvolve"]),
         .target(
             name: "SwiftEvolve",
-            dependencies: ["SwiftSyntax", "Utility"]),
+            dependencies: ["Utility"]),
         .testTarget(
           name: "SwiftEvolveTests",
           dependencies: ["SwiftEvolve"])

--- a/SwiftEvolve/Utilities/evolve-swiftCore.sh
+++ b/SwiftEvolve/Utilities/evolve-swiftCore.sh
@@ -118,7 +118,7 @@ function mixLibs() {
 
 # Build and test a stock version of Swift.
 phase="Current Modules, Current Binaries"
-buildSwift --llbuild --swiftpm --swiftsyntax --swiftevolve
+buildSwift --swiftsyntax --swiftevolve
 testSwift
 
 # Modify the standard library.

--- a/SwiftEvolve/Utilities/evolve-swiftCore.sh
+++ b/SwiftEvolve/Utilities/evolve-swiftCore.sh
@@ -66,7 +66,7 @@ function testSwift() {
 
 # Modify swift/stdlib source code.
 function evolveSwift() {
-  run "Evolving Swift source code" env SWIFT_EXEC="$BUILD_SWIFT/bin/swiftc" $BUILD/swiftevolve-macosx-x86_64/x86_64-apple-macosx/debug/swift-evolve --replace --rules=$EVOLVE/Utilities/swiftCore-exclude.json $ROOT/swift/stdlib/public/core/*.swift
+  run "Evolving Swift source code" env SWIFT_EXEC="$BUILD_SWIFT/bin/swiftc" $BUILD/swiftevolve-macosx-x86_64/debug/swift-evolve --replace --rules=$EVOLVE/Utilities/swiftCore-exclude.json $ROOT/swift/stdlib/public/core/*.swift
 }
 
 # Generate a diff of swift/stdlib.

--- a/SwiftEvolve/Utilities/evolve-swiftCore.sh
+++ b/SwiftEvolve/Utilities/evolve-swiftCore.sh
@@ -66,7 +66,7 @@ function testSwift() {
 
 # Modify swift/stdlib source code.
 function evolveSwift() {
-  run "Evolving Swift source code" env PATH="$BUILD/swiftpm-macosx-x86_64/x86_64-apple-macosx/debug:$PATH" swift run --package-path $EVOLVE swift-evolve --replace --rules=$EVOLVE/Utilities/swiftCore-exclude.json $ROOT/swift/stdlib/public/core/*.swift
+  run "Evolving Swift source code" env SWIFT_EXEC="$BUILD_SWIFT/bin/swiftc" $BUILD/swiftevolve-macosx-x86_64/x86_64-apple-macosx/debug/swift-evolve --replace --rules=$EVOLVE/Utilities/swiftCore-exclude.json $ROOT/swift/stdlib/public/core/*.swift
 }
 
 # Generate a diff of swift/stdlib.
@@ -118,7 +118,7 @@ function mixLibs() {
 
 # Build and test a stock version of Swift.
 phase="Current Modules, Current Binaries"
-buildSwift --llbuild --swiftpm --swiftsyntax
+buildSwift --llbuild --swiftpm --swiftsyntax --swiftevolve
 testSwift
 
 # Modify the standard library.

--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python
+
+"""
+  This source file is part of the Swift.org open source project
+ 
+  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+ ------------------------------------------------------------------------------
+ This is a helper script for the main swift repository's build-script.py that
+ knows how to build and install the stress tester utilities given a swift
+ workspace.
+
+"""
+
+from __future__ import print_function
+
+import argparse
+import sys
+import os
+import subprocess
+
+PACKAGE_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+
+def main():
+  args = parse_args(sys.argv[1:])
+  run(args)
+
+
+def parse_args(args):
+  parser = argparse.ArgumentParser(prog='BUILD-SCRIPT-HELPER.PY')
+
+  parser.add_argument('-v', '--verbose', action='store_true', help='log executed commands')
+  parser.add_argument('--prefix', help='install path')
+  parser.add_argument('--config', default='release')
+  parser.add_argument('--build-dir', default=os.path.join(PACKAGE_DIR, '.build'))
+  parser.add_argument('--swiftc-exec', help='the compiler to use when building this package (default: xcrun -f swiftc)')
+  parser.add_argument('--swift-build-exec', help='the swift-build exec to use to build this package (default: xcrun -f swift-build)')
+  parser.add_argument('--swift-test-exec', help='the swift-test exec to use to test this package (default: xcrun -f swift-test)')
+  parser.add_argument('--swift-package-exec', help='the swift-package exec to use to generate an xcode project for this package (default: xcrun -f swift-package)')
+  parser.add_argument('--sourcekitd-dir', help='the directory containing the sourcekitd.framework to use (default: relative to swiftc-exec)')
+  parser.add_argument('--swiftsyntax-dir', help='the directory containing SwiftSyntax\'s build products (libSwiftSyntax.dylib, and SwiftSyntax.swiftmodule)')
+  parser.add_argument('build_actions', help="Extra actions to perform. Can be any number of the following: [all, test, install, generate-xcodeproj]", nargs="*", default=[])
+
+  parsed = parser.parse_args(args)
+
+  if ("install" in parsed.build_actions or "all" in parsed.build_actions) and not parsed.prefix:
+    ArgumentParser.error("'--prefix' is required with the install action")
+  if parsed.swiftc_exec is None:
+    parsed.swiftc_exec = find_executable('swiftc')
+  if parsed.swift_build_exec is None:
+    parsed.swift_build_exec = find_executable('swift-build')
+  if parsed.swift_test_exec is None:
+    parsed.swift_test_exec = find_executable('swift-test')
+  if parsed.swift_package_exec is None:
+    parsed.swift_package_exec = find_executable('swift-package')
+  if parsed.sourcekitd_dir is None:
+    parsed.sourcekitd_dir = os.path.join(os.path.dirname(os.path.dirname(parsed.swiftc_exec)), 'lib')
+
+  return parsed
+
+
+def run(args):
+  if args.swiftsyntax_dir is None:
+    print("** Building SwiftSyntax **")
+    swiftsyntax_build_dir = os.path.join(PACKAGE_DIR, '.swiftsyntax_build')
+    build_swiftsyntax(swift_build_exec=args.swift_build_exec,
+      swiftc_exec=args.swiftc_exec,
+      build_dir=swiftsyntax_build_dir,
+      config=args.config,
+      verbose=args.verbose)
+    args.swiftsyntax_dir = os.path.join(swiftsyntax_build_dir, args.config)
+
+  sourcekit_searchpath=args.sourcekitd_dir
+  swiftsyntax_searchpath=args.swiftsyntax_dir
+
+  print("** Building Swift Stress Tester **")
+  build_package(swift_build_exec=args.swift_build_exec,
+    swiftc_exec=args.swiftc_exec,
+    sourcekit_searchpath=sourcekit_searchpath,
+    swiftsyntax_searchpath=swiftsyntax_searchpath,
+    build_dir=args.build_dir,
+    config=args.config,
+    verbose=args.verbose)
+
+  output_dir = os.path.realpath(os.path.join(args.build_dir, args.config))
+
+  if "generate-xcodeproj" in args.build_actions or "all" in args.build_actions:
+    print("** Generating Xcode project for Swift Stress Tester")
+    generate_xcodeproj(swift_package_exec=args.swift_package_exec,
+      sourcekit_searchpath=sourcekit_searchpath,
+      swiftsyntax_searchpath=swiftsyntax_searchpath,
+      verbose=args.verbose)
+
+  if "test" in args.build_actions or "all" in args.build_actions:
+    print("** Testing Swift Stress Tester **")
+    build_package(swift_build_exec=args.swift_test_exec,
+    swiftc_exec=args.swiftc_exec,
+    sourcekit_searchpath=sourcekit_searchpath,
+    swiftsyntax_searchpath=swiftsyntax_searchpath,
+    # note: test uses a different build_dir so it doesn't interfere with the 'build' step's products before install
+    build_dir=os.path.join(args.build_dir, 'test-build'),
+    config='debug',
+    verbose=args.verbose)
+
+  if "install" in args.build_actions or "all" in args.build_actions:
+    print("** Installing Swift Stress Tester **")
+    stdlib_dir = os.path.join(os.path.dirname(os.path.dirname(args.swiftc_exec)), 'lib', 'swift', 'macosx')
+    install_package(install_dir=args.prefix,
+      sourcekit_searchpath=sourcekit_searchpath,
+      swiftsyntax_searchpath=swiftsyntax_searchpath,
+      build_dir=output_dir,
+      rpaths_to_delete=[stdlib_dir],
+      verbose=args.verbose)
+
+
+def build_package(swift_build_exec, swiftc_exec, sourcekit_searchpath, swiftsyntax_searchpath, build_dir, config='release', verbose=False):
+  env = dict(os.environ)
+  env['SWIFT_EXEC'] = swiftc_exec
+
+  swiftc_args = ['-lSwiftSyntax', '-I', swiftsyntax_searchpath, '-L', swiftsyntax_searchpath, '-Fsystem', sourcekit_searchpath]
+  linker_args = ['-rpath', swiftsyntax_searchpath, '-rpath', sourcekit_searchpath]
+  args = [swift_build_exec, '--package-path', PACKAGE_DIR, '-c', config, '--build-path', build_dir] + interleave('-Xswiftc', swiftc_args) + interleave('-Xlinker', linker_args)
+  check_call(args, env=env, verbose=verbose)
+
+
+def install_package(install_dir, sourcekit_searchpath, swiftsyntax_searchpath, build_dir, rpaths_to_delete=[], verbose=False):
+  bin_dir = os.path.join(install_dir, 'bin')
+  lib_dir = os.path.join(install_dir, 'lib', 'swift', 'macosx')
+
+  for directory in [bin_dir, lib_dir]:
+    if not os.path.exists(directory):
+      os.makedirs(directory)
+
+  # Install sk-stress-test and sk-swiftc-wrapper
+  wrapper_src = os.path.join(build_dir, 'sk-swiftc-wrapper')
+  wrapper_dest = os.path.join(bin_dir, 'sk-swiftc-wrapper')
+  stress_tester_src = os.path.join(build_dir, 'sk-stress-test')
+  stress_tester_dest = os.path.join(bin_dir, 'sk-stress-test')
+  rpaths_to_delete += [sourcekit_searchpath, swiftsyntax_searchpath]
+  rpaths_to_add = ['@executable_path/../lib/swift/macosx', '@executable_path/../lib']
+  swiftsyntax_src = os.path.join(swiftsyntax_searchpath, 'libSwiftSyntax.dylib')
+  loadpath_changes = {os.path.realpath(swiftsyntax_src): '@rpath/libswiftSwiftSyntax.dylib'}
+
+  install(wrapper_src, wrapper_dest,
+    rpaths_to_delete=rpaths_to_delete,
+    rpaths_to_add=rpaths_to_add,
+    loadpath_changes=loadpath_changes,
+    verbose=verbose)
+  install(stress_tester_src, stress_tester_dest,
+    rpaths_to_delete=rpaths_to_delete,
+    rpaths_to_add=rpaths_to_add,
+    loadpath_changes=loadpath_changes,
+    verbose=verbose)
+
+
+def install(src, dest, rpaths_to_delete=[], rpaths_to_add=[], loadpath_changes={}, dylib_id=None, verbose=False):
+  copy_cmd=['rsync', '-a', src, dest]
+  print('installing %s to %s' % (os.path.basename(src), dest))
+  check_call(copy_cmd, verbose=verbose)
+
+  if dylib_id is not None:
+    check_call(['install_name_tool', '-id', dylib_id, dest], verbose=verbose)
+
+  for rpath in rpaths_to_delete:
+    remove_rpath(dest, rpath, verbose=verbose)
+  for rpath in rpaths_to_add:
+    add_rpath(dest, rpath, verbose=verbose)
+
+  for key, value in loadpath_changes.iteritems():
+    check_call(['install_name_tool', '-change', key, value, dest], verbose=verbose)
+
+
+def build_swiftsyntax(swift_build_exec, swiftc_exec, build_dir, config='release', verbose=False):
+  workspace = os.path.dirname(os.path.dirname(PACKAGE_DIR))
+  cmd = [os.path.join(workspace, 'swift-syntax', 'build-script.py'),
+    '--build-dir', os.path.join(PACKAGE_DIR, '.swiftsyntax_build'),
+    '--swiftc-exec', swiftc_exec,
+    '--swift-build-exec', swift_build_exec]
+
+  if config == 'release':
+    cmd += ['--release']
+
+  env = dict(os.environ)
+  check_call(cmd, env=env, verbose=verbose)
+
+
+def generate_xcodeproj(swift_package_exec, sourcekit_searchpath, swiftsyntax_searchpath, verbose=False):
+  config_path = os.path.join(PACKAGE_DIR, 'Config.xcconfig')
+  with open(config_path, 'w') as config_file:
+    config_file.write('''
+      SWIFT_INCLUDE_PATHS = {swiftsyntax_searchpath} $(inherited)
+      SYSTEM_FRAMEWORK_SEARCH_PATHS = {sourcekit_searchpath} $(inherited)
+      LIBRARY_SEARCH_PATHS = {swiftsyntax_searchpath} $(inherited)
+      LD_RUNPATH_SEARCH_PATHS = {sourcekit_searchpath} {swiftsyntax_searchpath} $(inherited)
+    '''.format(sourcekit_searchpath=sourcekit_searchpath, swiftsyntax_searchpath=swiftsyntax_searchpath))
+
+  env = dict(os.environ)
+  args = [swift_package_exec, 'generate-xcodeproj', '--xcconfig-overrides', config_path, '--output', os.path.join(PACKAGE_DIR, 'SourceKitStressTester.xcodeproj')]
+  check_call(args, env=env, verbose=verbose)
+
+def add_rpath(binary, rpath, verbose=False):
+  cmd = ['install_name_tool', '-add_rpath', rpath, binary]
+  check_call(cmd, verbose=verbose)
+
+
+def remove_rpath(binary, rpath, verbose=False):
+  cmd = ['install_name_tool', '-delete_rpath', rpath, binary]
+  check_call(cmd, verbose=verbose)
+
+
+def check_output(cmd, env=os.environ, verbose=False, **kwargs):
+  if verbose:
+    print(' '.join([escape_cmd_arg(arg) for arg in cmd]))
+  return subprocess.check_output(cmd, env=env, stderr=subprocess.STDOUT, **kwargs)
+
+
+def check_call(cmd, env=os.environ, verbose=False, **kwargs):
+  if verbose:
+    print(' '.join([escape_cmd_arg(arg) for arg in cmd]))
+  return subprocess.check_call(cmd, env=env, stderr=subprocess.STDOUT, **kwargs)
+
+
+def interleave(value, list):
+    return [item for pair in zip([value] * len(list), list) for item in pair]
+
+
+def find_executable(executable, toolchain=None):
+  if os.path.isfile(executable) and os.access(executable, os.X_OK):
+      return executable
+  extra_args = ['--toolchain', toolchain] if toolchain else []
+  return check_output(['xcrun', '-f', executable] + extra_args).rstrip()
+
+
+def escape_cmd_arg(arg):
+  if '"' in arg or ' ' in arg:
+    return '"%s"' % arg.replace('"', '\\"')
+  else:
+    return arg
+
+if __name__ == '__main__':
+  main()

--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -145,14 +145,15 @@ def install_package(package_dir, install_dir, sourcekit_searchpath, swiftsyntax_
     if not os.path.exists(directory):
       os.makedirs(directory)
 
+  rpaths_to_delete += [sourcekit_searchpath, swiftsyntax_searchpath]
+  rpaths_to_add = ['@executable_path/../lib/swift/macosx', '@executable_path/../lib']
+  swiftsyntax_src = os.path.join(swiftsyntax_searchpath, 'libSwiftSyntax.dylib')
+  loadpath_changes = {os.path.realpath(swiftsyntax_src): '@rpath/libswiftSwiftSyntax.dylib'}
+
   # Install sk-stress-test and sk-swiftc-wrapper
   for product in get_products(package_dir):
     src = os.path.join(build_dir, product)
     dest = os.path.join(bin_dir, product)
-    rpaths_to_delete += [sourcekit_searchpath, swiftsyntax_searchpath]
-    rpaths_to_add = ['@executable_path/../lib/swift/macosx', '@executable_path/../lib']
-    swiftsyntax_src = os.path.join(swiftsyntax_searchpath, 'libSwiftSyntax.dylib')
-    loadpath_changes = {os.path.realpath(swiftsyntax_src): '@rpath/libswiftSwiftSyntax.dylib'}
 
     install(src, dest,
       rpaths_to_delete=rpaths_to_delete,

--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -23,8 +23,8 @@ import sys
 import os
 import subprocess
 
-def main():
-  args = parse_args(sys.argv[1:])
+def main(argv_prefix = []):
+  args = parse_args(argv_prefix + sys.argv[1:])
   run(args)
 
 def parse_args(args):

--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -64,7 +64,7 @@ def parse_args(args):
                         os.path.join(repo_path, parsed.package_dir))
 
   # Convert build_dir to absolute path, relative to package_dir.
-  parsed.build_dir = os.path.join(parsed.package_dir, '.build')
+  parsed.build_dir = os.path.join(parsed.package_dir, parsed.build_dir)
 
   return parsed
 


### PR DESCRIPTION
This change pulls build-script-helper up to the root of the repository and adds a --package-dir option so it can build either SourceKitStressTester or SwiftEvolve.

Actually using this script requires matching changes in apple/swift#21523; to help ease the transition, this commit leaves a shim script at SourceKitStressTester/Utilities/build-script-helper.sh.

To do:

- [x] Give this a once-over for style
- [x] See if I can make the old build-script-helper call through to the new one for compatibility
- [ ] Get this reviewed by Nathan