### PR TITLE
[WIP] Speed up swift-evolve by using SwiftLang and byte trees

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/SwiftEvolveTool.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SwiftEvolveTool.swift
@@ -16,6 +16,7 @@
 
 import Foundation
 import SwiftSyntax
+import SwiftLang
 import Basic
 
 public class SwiftEvolveTool {
@@ -168,9 +169,18 @@ extension SwiftEvolveTool {
     if let preparsed = parsedSourceFiles[path] {
       return preparsed
     }
-    let parsed = try SyntaxTreeParser.parse(URL(path))
+
+    let parsed = try SwiftLang.parse(contentsOf: URL(path), into: .swiftSyntax)
     parsedSourceFiles[path] = parsed
     return parsed
+  }
+}
+
+extension SwiftLang.SyntaxTreeFormat {
+  static var swiftSyntax: SwiftLang.SyntaxTreeFormat<SourceFileSyntax> {
+    return byteTree.withTreeMapped {
+      try SyntaxTreeDeserializer().deserialize($0, serializationFormat: .byteTree)
+    }
   }
 }
 

--- a/SwiftEvolve/Tests/SwiftEvolveTests/RegressionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/RegressionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SwiftSyntax
+import SwiftLang
 @testable import SwiftEvolve
 
 class RegressionTests: XCTestCase {
@@ -9,7 +10,7 @@ class RegressionTests: XCTestCase {
     // Checks that we don't mess up the order of declarations we're not trying
     // to shuffle. In particular, if we store the properties in a Set or other
     // unordered collection, we could screw this up.
-    try SyntaxTreeParser.withParsedCode(
+    try SwiftLang.withParsedCode(
       """
       @_fixed_layout struct X {
         var p0: Int
@@ -48,7 +49,7 @@ class RegressionTests: XCTestCase {
     // FIXME: Crashes when run in Xcode because of a version mismatch between
     // SwiftSyntax and the compiler it uses (specifically, how they represent
     // accessor blocks). Should pass in "env PATH=... swift build".
-    try SyntaxTreeParser.withParsedCode(
+    try SwiftLang.withParsedCode(
       """
       struct A {
         #if os(iOS)
@@ -82,7 +83,7 @@ class RegressionTests: XCTestCase {
       }
     }
 
-    try SyntaxTreeParser.withParsedCode(
+    try SwiftLang.withParsedCode(
       """
       struct B {
         var b1: Int
@@ -116,7 +117,7 @@ class RegressionTests: XCTestCase {
       }
     }
 
-    try SyntaxTreeParser.withParsedCode(
+    try SwiftLang.withParsedCode(
       """
       struct C {
         #if os(iOS)

--- a/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleMembersEvolutionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleMembersEvolutionTests.swift
@@ -1,12 +1,13 @@
 import XCTest
 import SwiftSyntax
+import SwiftLang
 @testable import SwiftEvolve
 
 class ShuffleMembersEvolutionTests: XCTestCase {
   var predictableRNG = PredictableGenerator(values: 0..<16)
 
   func testEnumCases() throws {
-    try SyntaxTreeParser.withParsedCode(
+    try SwiftLang.withParsedCode(
       """
       enum Foo {
         case a

--- a/SwiftEvolve/Tests/SwiftEvolveTests/TestUtils.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/TestUtils.swift
@@ -1,18 +1,20 @@
 import XCTest
 import SwiftSyntax
+import SwiftLang
 @testable import SwiftEvolve
 import Basic
 
-extension SyntaxTreeParser {
+extension SwiftLang {
   static func withParsedCode(
     _ code: String, do body: (SourceFileSyntax) throws -> Void
-    ) throws -> Void {
+  ) throws -> Void {
     try withExtendedLifetime(
       TemporaryFile(dir: nil, prefix: "test", suffix: "swift", deleteOnClose: true)
     ) { tempFile in
       tempFile.fileHandle.write(code)
       tempFile.fileHandle.synchronizeFile()
-      try body(parse(URL(tempFile.path)))
+      let tree = try parse(contentsOf: URL(tempFile.path), into: .swiftSyntax)
+      try body(tree)
     }
   }
 }


### PR DESCRIPTION
swift-evolve spends most of its time parsing the JSON in the parser’s syntax tree; using the byte-tree format instead is dramatically more efficient. With this change, evolving swift/stdlib/public/core/Integers.swift goes from 145 seconds to 55 seconds (real time).

Requires the new byte tree API being developed in apple/swift#21542, plus the new build system integration in #26 (temporarily incorporated into this PR too) and apple/swift#21523.

To do:

- [x] Wait for prerequisites to land
- [x] Rebase on #26
- [x] Update to match whatever API develops in apple/swift#21542
- [x] Review