### PR TITLE
Remove a couple missed undefined PACKAGE_DIR references in build-script-helper.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Swift Stress Tester
 
-This project aims to provide stress testing utilities to help find reproducible crashes and other failures in tools that process Swift source code, such as the Swift compiler and SourceKit. These utilities will ideally be written in Swift and make use the SwiftSyntax and SwiftLang libraries to parse, generate and modify Swift source inputs.
+This project aims to provide stress testing utilities to help find reproducible crashes and other failures in tools that process Swift source code, such as the Swift compiler and SourceKit. These utilities will ideally be written in Swift and make use the SwiftSyntax and/or SwiftLang libraries to parse, generate and modify Swift source inputs.
 
 ## Current tools
 
@@ -25,16 +25,17 @@ $ ./utils/build-script -t --swiftsyntax --skstresstester
 
 ### For local development
 
-For local development you'll need to have the [Swift](https://github.com/apple/swift) and [SwiftSyntax](https://github.com/apple/swift-syntax) repositories checked out adjacent to the swift-stress-tester repository in the structure shown below:
+For local development you'll first need to download and install a recent [swift.org development snapshot](https://swift.org/download/#snapshots) toolchain. You'll also need to have the [Swift](https://github.com/apple/swift) and [SwiftSyntax](https://github.com/apple/swift-syntax) repositories checked out adjacent to the swift-stress-tester repository in the structure shown below:
 ```
 <workspace>/
 swift/
 swift-syntax/
 swift-stress-tester/
 ```
-If you installed the Swift 5.0 development toolchain be sure to check out `swift-5.0-branch`, rather than `master` in all of these repositories before continuing with the instructions below.
 
-### Via Xcode
+Also make sure you've checked out the branch corresponding to the development snapshot you installed (e.g. master for trunk, or swift-5.0-branch for Swift 5.0) in all of these repositories.
+
+#### Via Xcode
 
 To generate an Xcode project that's set up correctly, run `build-script-helper.py`, passing the path to the swiftc executable in the downloaded toolchain via the `--swiftc-exec` option, the tool's package name in the `--package-dir` option, and the `generate-xcodeproj` action:
 ```
@@ -42,7 +43,7 @@ $ ./build-script-helper.py --package-dir SourceKitStressTester --swiftc-exec $TO
 ```
 This will generate `SourceKitStressTester/SourceKitStressTester.xcodeproj`. Open it and select the toolchain you installed from the Xcode > Toolchains menu, before building the `SourceKitStressTester-Package` scheme.
 
-### Via command line
+#### Via command line
 
 To build, run `build-script-helper.py`, passing the path to the swiftc executable in the downloaded toolchain via the `--swiftc-exec` option and the tool's package name in the `--package-dir` option:
 ```

--- a/SourceKitStressTester/Utilities/build-script-helper.py
+++ b/SourceKitStressTester/Utilities/build-script-helper.py
@@ -24,7 +24,7 @@ import os
 
 def main():
   print("(Using swift-stress-tester build compatibility shim...)")
-  impl_script = ImplScript(__file__)
+  impl_script = ImplScript(os.path.realpath(__file__))
   impl_main = impl_script.get_local('main')
   impl_main(['--package-dir', impl_script.package_dir])
 

--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -73,8 +73,10 @@ def parse_args(args):
 def run(args):
   if args.swiftsyntax_dir is None:
     print("** Building SwiftSyntax **")
-    swiftsyntax_build_dir = os.path.join(PACKAGE_DIR, '.swiftsyntax_build')
-    build_swiftsyntax(swift_build_exec=args.swift_build_exec,
+    workspace = os.path.dirname(os.path.dirname(args.package_dir))
+    swiftsyntax_build_dir = os.path.join(args.package_dir, '.swiftsyntax_build')
+    build_swiftsyntax(repo=os.path.join(workspace, 'swift-syntax'),
+      swift_build_exec=args.swift_build_exec,
       swiftc_exec=args.swiftc_exec,
       parser_header_dir=args.syntax_parser_header_dir,
       parser_lib_dir=args.syntax_parser_lib_dir,
@@ -195,10 +197,9 @@ def install(src, dest, rpaths_to_delete=[], rpaths_to_add=[], loadpath_changes={
     check_call(['install_name_tool', '-change', key, value, dest], verbose=verbose)
 
 
-def build_swiftsyntax(swift_build_exec, swiftc_exec, parser_header_dir, parser_lib_dir, build_dir, config='release', verbose=False):
-  workspace = os.path.dirname(os.path.dirname(PACKAGE_DIR))
-  cmd = [os.path.join(workspace, 'swift-syntax', 'build-script.py'),
-    '--build-dir', os.path.join(PACKAGE_DIR, '.swiftsyntax_build'),
+def build_swiftsyntax(repo, swift_build_exec, swiftc_exec, parser_header_dir, parser_lib_dir, build_dir, config='release', verbose=False):
+  cmd = [os.path.join(repo, 'build-script.py'),
+    '--build-dir', build_dir,
     '--swiftc-exec', swiftc_exec,
     '--swift-build-exec', swift_build_exec]
   if parser_header_dir:
@@ -224,7 +225,7 @@ def generate_xcodeproj(package_dir, swift_package_exec, sourcekit_searchpath, sw
     '''.format(sourcekit_searchpath=sourcekit_searchpath, swiftsyntax_searchpath=swiftsyntax_searchpath))
 
   env = dict(os.environ)
-  args = [swift_package_exec, 'generate-xcodeproj', '--xcconfig-overrides', config_path, '--output', os.path.join(package_dir, 'SourceKitStressTester.xcodeproj')]
+  args = [swift_package_exec, '--package-path', package_dir, 'generate-xcodeproj', '--xcconfig-overrides', config_path, '--output', os.path.join(package_dir, 'SourceKitStressTester.xcodeproj')]
   check_call(args, env=env, verbose=verbose)
 
 def add_rpath(binary, rpath, verbose=False):


### PR DESCRIPTION
Also tweak the readme a bit to mention needing a recent toolchain to be installed (that has the new parser library SwiftSyntax now needs) and update the stress tester's compatibility shim build-script-helper to handle being invoked with a relative path.