### PR TITLE
[5.0] Switch ProcessRunner.run() to use readDataToEndOfFile, rather than readabilityHandler for capturing output

### DIFF
--- a/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
@@ -83,7 +83,6 @@ final class StressTestOperation: Operation {
           status: \(status)
           args: \(process.process.arguments?.joined(separator: " ") ?? "")
           stdout: \(String(data: result.stdout, encoding: .utf8) ?? "")
-          stderr: \(String(data: result.stderr, encoding: .utf8) ?? "")
         """)
     }
   }


### PR DESCRIPTION
Cherry-pick of fix from master.