### PR TITLE
[DNM] Change the loadpath for installed SwiftSyntax

### DIFF
--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -167,7 +167,7 @@ def install_package(package_dir, install_dir, sourcekit_searchpath, swiftsyntax_
   rpaths_to_delete += [sourcekit_searchpath, swiftsyntax_searchpath]
   rpaths_to_add = ['@executable_path/../lib/swift/macosx', '@executable_path/../lib']
   swiftsyntax_src = os.path.join(swiftsyntax_searchpath, 'libSwiftSyntax.dylib')
-  loadpath_changes = {os.path.realpath(swiftsyntax_src): '@rpath/libswiftSwiftSyntax.dylib'}
+  loadpath_changes = {os.path.realpath(swiftsyntax_src): '@rpath/libSwiftSyntax.dylib'}
 
   # Install sk-stress-test and sk-swiftc-wrapper
   for product in get_products(package_dir):


### PR DESCRIPTION
SwiftSyntax now installs itself as “libSwiftSyntax.dylib” instead of “libswiftSwiftSyntax.dylib”; this change updates build-script-helper to match.

I will test this by building a toolchain in an apple/swift PR, so don't merge it right away.