### PR TITLE
[SourceKitStressTester] Update to fix breakage from recent SwiftSyntax API changes

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/Action.swift
+++ b/SourceKitStressTester/Sources/StressTester/Action.swift
@@ -11,45 +11,30 @@
 //===----------------------------------------------------------------------===//
 
 enum Action {
-  case cursorInfo(position: SourcePosition)
-  case codeComplete(position: SourcePosition)
-  case rangeInfo(range: SourceRange)
-  case replaceText(range: SourceRange, text: String)
-}
-
-struct SourcePosition: Equatable, Codable {
-  let offset: Int
-  let line: Int
-  let column: Int
-}
-
-struct SourceRange: Equatable, Codable {
-  let start: SourcePosition
-  let end: SourcePosition
-  let length: Int
-  var offset: Int { return start.offset }
-  var endOffset: Int { return start.offset + length }
-  var isEmpty: Bool { return length == 0 }
+  case cursorInfo(offset: Int)
+  case codeComplete(offset: Int)
+  case rangeInfo(offset: Int, length: Int)
+  case replaceText(offset: Int, length: Int, text: String)
 }
 
 extension Action: CustomStringConvertible {
   var description: String {
     switch self {
-    case .cursorInfo(let position):
-      return "CusorInfo at \(position.line):\(position.column)"
-    case .codeComplete(let position):
-      return "CodeComplete at \(position.line):\(position.column)"
-    case .rangeInfo(let range):
-      return "RangeInfo from \(range.start.line):\(range.start.column) to \(range.end.line):\(range.end.column)"
-    case .replaceText(let range, let text):
-      return "ReplaceText from \(range.start.line):\(range.start.column) to \(range.end.line):\(range.end.column) with \(text.debugDescription)"
+    case .cursorInfo(let offset):
+      return "CusorInfo at offset \(offset)"
+    case .codeComplete(let offset):
+      return "CodeComplete at offset \(offset)"
+    case .rangeInfo(let from, let length):
+      return "RangeInfo from offset \(from) for length \(length)"
+    case .replaceText(let from, let length, let text):
+      return "ReplaceText from offset \(from) for length \(length) with \(text.debugDescription)"
     }
   }
 }
 
 extension Action: Codable {
   enum CodingKeys: String, CodingKey {
-    case action, position, range, text
+    case action, offset, length, text
   }
   enum BaseAction: String, Codable {
     case cursorInfo, codeComplete, rangeInfo, replaceText
@@ -59,36 +44,40 @@ extension Action: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     switch try container.decode(BaseAction.self, forKey: .action) {
     case .cursorInfo:
-      let position = try container.decode(SourcePosition.self, forKey: .position)
-      self = .cursorInfo(position: position)
+      let offset = try container.decode(Int.self, forKey: .offset)
+      self = .cursorInfo(offset: offset)
     case .codeComplete:
-      let position = try container.decode(SourcePosition.self, forKey: .position)
-      self = .codeComplete(position: position)
+      let offset = try container.decode(Int.self, forKey: .offset)
+      self = .codeComplete(offset: offset)
     case .rangeInfo:
-      let range = try container.decode(SourceRange.self, forKey: .range)
-      self = .rangeInfo(range: range)
+      let offset = try container.decode(Int.self, forKey: .offset)
+      let length = try container.decode(Int.self, forKey: .length)
+      self = .rangeInfo(offset: offset, length: length)
     case .replaceText:
-      let range = try container.decode(SourceRange.self, forKey: .range)
+      let offset = try container.decode(Int.self, forKey: .offset)
+      let length = try container.decode(Int.self, forKey: .length)
       let text = try container.decode(String.self, forKey: .text)
-      self = .replaceText(range: range, text: text)
+      self = .replaceText(offset: offset, length: length, text: text)
     }
   }
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     switch self {
-    case .cursorInfo(let position):
+    case .cursorInfo(let offset):
       try container.encode(BaseAction.cursorInfo, forKey: .action)
-      try container.encode(position, forKey: .position)
-    case .codeComplete(let position):
+      try container.encode(offset, forKey: .offset)
+    case .codeComplete(let offset):
       try container.encode(BaseAction.codeComplete, forKey: .action)
-      try container.encode(position, forKey: .position)
-    case .rangeInfo(let range):
+      try container.encode(offset, forKey: .offset)
+    case .rangeInfo(let startOffset, let length):
       try container.encode(BaseAction.rangeInfo, forKey: .action)
-      try container.encode(range, forKey: .range)
-    case .replaceText(let range, let text):
+      try container.encode(startOffset, forKey: .offset)
+      try container.encode(length, forKey: .length)
+    case .replaceText(let offset, let length, let text):
       try container.encode(BaseAction.replaceText, forKey: .action)
-      try container.encode(range, forKey: .range)
+      try container.encode(offset, forKey: .offset)
+      try container.encode(length, forKey: .length)
       try container.encode(text, forKey: .text)
     }
   }

--- a/SourceKitStressTester/Sources/StressTester/StressTester.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTester.swift
@@ -80,8 +80,8 @@ struct StressTester {
     // Compute the initial state of the source file for this page
     var state = SourceState(rewriteMode: options.rewriteMode, content: source)
     pages[0..<options.page.index].joined().forEach {
-      if case .replaceText(let range, let text) = $0 {
-        state.replace(range, with: text)
+      if case .replaceText(let offset, let length, let text) = $0 {
+        state.replace(offset: offset, length: length, with: text)
       }
     }
     return (state, page)
@@ -114,29 +114,29 @@ struct StressTester {
 
     // Run all requests that can reuse a single AST together for improved
     // runtime
-    let cursorInfos = actions.compactMap { action -> SourcePosition? in
-      guard case .cursorInfo(let position) = action else { return nil }
-      return position
+    let cursorInfos = actions.compactMap { action -> Int? in
+      guard case .cursorInfo(let offset) = action else { return nil }
+      return offset
     }
-    let rangeInfos = actions.compactMap { action -> SourceRange? in
+    let rangeInfos = actions.compactMap { action -> (offset: Int, length: Int)? in
       guard case .rangeInfo(let range) = action else { return nil }
       return range
     }
-    let codeCompletions = actions.compactMap { action -> SourcePosition? in
-      guard case .codeComplete(let position) = action else { return nil }
-      return position
+    let codeCompletions = actions.compactMap { action -> Int? in
+      guard case .codeComplete(let offset) = action else { return nil }
+      return offset
     }
 
-    for position in cursorInfos {
-      _ = try document.cursorInfo(position: position)
+    for offset in cursorInfos {
+      _ = try document.cursorInfo(offset: offset)
     }
 
     for range in rangeInfos {
-      _ = try document.rangeInfo(start: range.start, length: range.length)
+      _ = try document.rangeInfo(offset: range.offset, length: range.length)
     }
 
-    for position in codeCompletions {
-      _ = try document.codeComplete(offset: position.offset)
+    for offset in codeCompletions {
+      _ = try document.codeComplete(offset: offset)
     }
 
     _ = try document.close()
@@ -155,14 +155,14 @@ struct StressTester {
 
     for action in actions {
       switch action {
-      case .cursorInfo(let position):
-        _ = try document.cursorInfo(position: position)
-      case .codeComplete(let position):
-        _ = try document.codeComplete(offset: position.offset)
-      case .rangeInfo(let range):
-        _ = try document.rangeInfo(start: range.start, length: range.length)
-      case .replaceText(let range, let text):
-        _ = try document.replaceText(range: range, text: text)
+      case .cursorInfo(let offset):
+        _ = try document.cursorInfo(offset: offset)
+      case .codeComplete(let offset):
+        _ = try document.codeComplete(offset: offset)
+      case .rangeInfo(let offset, let length):
+        _ = try document.rangeInfo(offset: offset, length: length)
+      case .replaceText(let offset, let length, let text):
+        _ = try document.replaceText(offset: offset, length: length, text: text)
       }
     }
 

--- a/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
@@ -65,7 +65,7 @@ public struct StressTesterTool {
     // option. There is no support for '--' to separate positionals at present.
     compilerArgs = parser.add(
       positional: "swiftc <compiler-args>", kind: [String].self, strategy: .remaining,
-      usage: "swift compiler arguments for the provided file", completion: .none)
+      usage: "swift compiler arguments for the provided file")
 
   }
 


### PR DESCRIPTION
SwiftSyntax's `AbsolutePosition` and `SourceLength` no longer track line and column, just offset.

The stress tester only really needs the line and column for the SemanticRefactoring request, which doesn't accept offset at the moment, so I've updated the various `ActionGenerator`s to just return the offset in the `Action`s they generate. `SourceKitDocument` now computes the line/column from the offset on-demand whenever a SemanticRefactoring request is made, using SwiftSyntax's new `SourceLocationConverter` and the current `SyntaxTree` of the document.