### PR TITLE
Add evolution to shuffle generic where constraints

### DIFF
--- a/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleGenericRequirementsEvolutionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleGenericRequirementsEvolutionTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import SwiftSyntax
+import SwiftLang
+@testable import SwiftEvolve
+
+class ShuffleGenericRequirementsEvolutionTests: XCTestCase {
+  var predictableRNG = PredictableGenerator(values: 1..<16)
+
+  func testEvolution() throws {
+    let code = try SyntaxParser.parse(source:
+      """
+      func foo<T>(_: T) where T: Hashable, T == Comparable {}
+      """
+    )
+    let decl = code.filter(whereIs: FunctionDeclSyntax.self).first!
+    let dc = DeclContext(declarationChain: [code, decl])
+
+    let evo = try ShuffleGenericRequirementsEvolution(
+      for: decl.genericWhereClause!.requirementList, in: dc, using: &predictableRNG
+    )
+
+    XCTAssertEqual(evo?.mapping.count, 2)
+
+    let evolved = evo?.evolve(decl.genericWhereClause!.requirementList)
+    XCTAssertEqual(evolved.map(String.init(describing:)),
+                   "T == Comparable , T: Hashable")
+  }
+
+  func testBypass() throws {
+    let code = try SyntaxParser.parse(source:
+      """
+      func foo<T>(_: T) where T: Hashable, T == Comparable {}
+      """
+    )
+    let decl = code.filter(whereIs: FunctionDeclSyntax.self).first!
+    let dc = DeclContext(declarationChain: [code, decl])
+
+    XCTAssertThrowsError(
+      try ShuffleGenericRequirementsEvolution(
+        for: decl.genericWhereClause!, in: dc, using: &predictableRNG
+      )
+    ) { error in
+      XCTAssertEqual(error as? EvolutionError, EvolutionError.unsupported)
+    }
+  }
+}


### PR DESCRIPTION
For instance, “where T: Foo, T: Bar” might become “where T: Bar, T: Foo”. Name mangling should always canonicalize them into the same form; shuffling them should catch any bugs in that code.