### PR TITLE
Update swift-evolve for recent swift-syntax api changes

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
@@ -440,7 +440,17 @@ extension IfConfigDeclSyntax {
 
 extension Optional where Wrapped == AttributeListSyntax {
   func contains(named name: String) -> Bool {
-    return self?.contains { $0.attributeName.text == name } ?? false
+    return self?.contains { 
+      if let builtinAttribute = $0 as? AttributeSyntax {
+        return builtinAttribute.attributeName.text == name 
+      } else if let customAttribute = $0 as? CustomAttributeSyntax {
+        // FIXME: Attribute name is a TypeSyntax, so .description isn't quite
+        // right here (e.g. @MyCustomAttribute<MyTypeParam> is valid)
+        return customAttribute.attributeName.description == name
+      } else {
+        preconditionFailure("unhandled AttributeListSyntax element kind")
+      }
+    } ?? false
   }
 }
 


### PR DESCRIPTION
AttributeListSyntax can now contain either AttributeSyntax or CustomAttributeSyntax.
Should fix the CI failures in https://ci.swift.org/job/oss-swift-package-osx/3254/

Resolves rdar://problem/50461341