### PR TITLE
[5.0][SourceKitStressTester] Add setting to limit sk-swiftc-wrapper's stderr/stdout output to that of the compiler

### DIFF
--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapperTool.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapperTool.swift
@@ -26,6 +26,8 @@ public struct SwiftCWrapperTool {
     let stressTesterEnv = EnvOption("SK_STRESS_TEST", type: String.self)
     let ignoreIssuesEnv = EnvOption("SK_STRESS_SILENT", type: Bool.self)
     let astBuildLimitEnv = EnvOption("SK_STRESS_AST_BUILD_LIMIT", type: Int.self)
+    /// Output only what the wrapped compiler outputs
+    let suppressOutputEnv = EnvOption("SK_STRESS_SUPPRESS_OUTPUT", type: Bool.self)
 
     // IssueManager params
     let expectedFailuresPathEnv = EnvOption("SK_XFAILS_PATH", type: String.self)
@@ -39,6 +41,7 @@ public struct SwiftCWrapperTool {
       throw EnvOptionError.noFallback(key: stressTesterEnv.key, target: "sk-stress-test")
     }
     let ignoreIssues = try ignoreIssuesEnv.get(from: environment) ?? false
+    let suppressOutput = try suppressOutputEnv.get(from: environment) ?? false
     let astBuildLimit = try astBuildLimitEnv.get(from: environment)
 
     var issueManager: IssueManager? = nil
@@ -58,7 +61,8 @@ public struct SwiftCWrapperTool {
                                 astBuildLimit: astBuildLimit,
                                 ignoreIssues: ignoreIssues,
                                 issueManager: issueManager,
-                                failFast: true)
+                                failFast: true,
+                                suppressOutput: suppressOutput)
     return try wrapper.run()
   }
 


### PR DESCRIPTION
This prevents sk-swiftc-wrapper from reporting progress/results inline to stderr, which was causing SwiftPM to fail the invocation with:

> error: failed parsing the Swift compiler output:  invalid message size

as it was passing -parseable-output to sk-swiftc-wrapper (which it thinks is swiftc) and the extra progress output the wrapper produces isn't parseable. The discovered issue messages are instead written to the results json file.