### PR TITLE
[5.1][SourceKitStressTester] Add support for stress testing the new ConformingMethodList, TypeContextInfo and CollectExpressionType requests

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/Action.swift
+++ b/SourceKitStressTester/Sources/StressTester/Action.swift
@@ -15,6 +15,9 @@ enum Action {
   case codeComplete(offset: Int)
   case rangeInfo(offset: Int, length: Int)
   case replaceText(offset: Int, length: Int, text: String)
+  case typeContextInfo(offset: Int)
+  case conformingMethodList(offset: Int)
+  case collectExpressionType
 }
 
 extension Action: CustomStringConvertible {
@@ -28,6 +31,12 @@ extension Action: CustomStringConvertible {
       return "RangeInfo from offset \(from) for length \(length)"
     case .replaceText(let from, let length, let text):
       return "ReplaceText from offset \(from) for length \(length) with \(text.debugDescription)"
+    case .typeContextInfo(let offset):
+      return "TypeContextInfo at offset \(offset)"
+    case .conformingMethodList(let offset):
+      return "ConformingMethodList at offset \(offset)"
+    case .collectExpressionType:
+      return "CollectExpressionType"
     }
   }
 }
@@ -37,7 +46,7 @@ extension Action: Codable {
     case action, offset, length, text
   }
   enum BaseAction: String, Codable {
-    case cursorInfo, codeComplete, rangeInfo, replaceText
+    case cursorInfo, codeComplete, rangeInfo, replaceText, typeContextInfo, conformingMethodList, collectExpressionType
   }
 
   public init(from decoder: Decoder) throws {
@@ -58,6 +67,14 @@ extension Action: Codable {
       let length = try container.decode(Int.self, forKey: .length)
       let text = try container.decode(String.self, forKey: .text)
       self = .replaceText(offset: offset, length: length, text: text)
+    case .typeContextInfo:
+      let offset = try container.decode(Int.self, forKey: .offset)
+      self = .typeContextInfo(offset: offset)
+    case .conformingMethodList:
+      let offset = try container.decode(Int.self, forKey: .offset)
+      self = .conformingMethodList(offset: offset)
+    case .collectExpressionType:
+      self = .collectExpressionType
     }
   }
 
@@ -79,6 +96,14 @@ extension Action: Codable {
       try container.encode(offset, forKey: .offset)
       try container.encode(length, forKey: .length)
       try container.encode(text, forKey: .text)
+    case .typeContextInfo(let offset):
+      try container.encode(BaseAction.typeContextInfo, forKey: .action)
+      try container.encode(offset, forKey: .offset)
+    case .conformingMethodList(let offset):
+      try container.encode(BaseAction.conformingMethodList, forKey: .action)
+      try container.encode(offset, forKey: .offset)
+    case .collectExpressionType:
+      try container.encode(BaseAction.collectExpressionType, forKey: .action)
     }
   }
 }

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -190,6 +190,56 @@ struct SourceKitDocument {
     return response
   }
 
+  func typeContextInfo(offset: Int) throws -> SourceKitdResponse {
+    let request = SourceKitdRequest(uid: .request_TypeContextInfo)
+
+    request.addParameter(.key_SourceFile, value: file)
+    request.addParameter(.key_Offset, value: offset)
+
+    let compilerArgs = request.addArrayParameter(.key_CompilerArgs)
+    for arg in args { compilerArgs.add(arg) }
+
+    let info = RequestInfo.typeContextInfo(document: documentInfo, offset: offset, args: args)
+    let response = try sendWithTimeout(request, info: info)
+    try throwIfInvalid(response, request: info)
+
+    return response
+  }
+
+  func conformingMethodList(offset: Int, typeList: [String]) throws -> SourceKitdResponse {
+    let request = SourceKitdRequest(uid: .request_ConformingMethodList)
+
+    request.addParameter(.key_SourceFile, value: file)
+    request.addParameter(.key_Offset, value: offset)
+
+    let expressionTypeList = request.addArrayParameter(.key_ExpressionTypeList)
+    for type in typeList { expressionTypeList.add(type) }
+
+    let compilerArgs = request.addArrayParameter(.key_CompilerArgs)
+    for arg in args { compilerArgs.add(arg) }
+
+    let info = RequestInfo.conformingMethodList(document: documentInfo, offset: offset, typeList: typeList, args: args)
+    let response = try sendWithTimeout(request, info: info)
+    try throwIfInvalid(response, request: info)
+
+    return response
+  }
+
+  func collectExpressionType() throws -> SourceKitdResponse {
+    let request = SourceKitdRequest(uid: .request_CollectExpressionType)
+
+    request.addParameter(.key_SourceFile, value: file)
+
+    let compilerArgs = request.addArrayParameter(.key_CompilerArgs)
+    for arg in args { compilerArgs.add(arg) }
+
+    let info = RequestInfo.collectExpressionType(document: documentInfo, args: args)
+    let response = try sendWithTimeout(request, info: info)
+    try throwIfInvalid(response, request: info)
+
+    return response
+  }
+
   mutating func replaceText(offset: Int, length: Int, text: String) throws -> (SourceFileSyntax, SourceKitdResponse) {
     let request = SourceKitdRequest(uid: .request_EditorReplaceText)
     request.addParameter(.key_Name, value: file)

--- a/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
@@ -30,6 +30,7 @@ public struct StressTesterTool {
   let page: OptionArgument<Page>
   let request: OptionArgument<[RequestSet]>
   let dryRun: OptionArgument<Bool>
+  let conformingMethodsTypeList: OptionArgument<[String]>
   let file: PositionalArgument<PathArgument>
   let compilerArgs: PositionalArgument<[String]>
 
@@ -52,10 +53,13 @@ public struct StressTesterTool {
       " and only performs the <PAGE>th group.")
     request = parser.add(
       option: "--request", shortName: "-r", kind: [RequestSet].self, strategy: .oneByOne,
-      usage: "<REQUEST> One of CursorInfo, RangeInfo, or CodeComplete")
+      usage: "<REQUEST> One of CursorInfo, RangeInfo, CodeComplete, TypeContextInfo, ConformingMethodList, CollectExpressionType, or All")
     dryRun = parser.add(
       option: "--dryrun", shortName: "-d", kind: Bool.self,
       usage: "Dump the actions the stress tester would perform instead of performing them")
+    conformingMethodsTypeList = parser.add(
+      option: "--type-list-item", shortName: "-t", kind: [String].self, strategy: .oneByOne,
+      usage: "The USR of a conformed-to protocol to use in the ConformingMethodList request")
     file = parser.add(
       positional: "<source-file>", kind: PathArgument.self, optional: false,
       usage: "A Swift source file to stress test", completion: .filename)
@@ -102,6 +106,9 @@ public struct StressTesterTool {
     }
     if let requests = arguments.get(request) {
       options.requests = requests.reduce([]) { result, next in result.union(next) }
+    }
+    if let typeList = arguments.get(conformingMethodsTypeList) {
+      options.conformingMethodsTypeList = typeList
     }
 
     let format = arguments.get(self.format) ?? .humanReadable
@@ -151,15 +158,21 @@ extension RequestSet: ArgumentKind {
   public init(argument: String) throws {
     switch argument.lowercased() {
     case "cursorinfo":
-        self = .cursorInfo
+      self = .cursorInfo
     case "rangeinfo":
-        self = .rangeInfo
+      self = .rangeInfo
     case "codecomplete":
-        self = .codeComplete
+      self = .codeComplete
+    case "typecontextinfo":
+      self = .typeContextInfo
+    case "conformingmethodlist":
+      self = .conformingMethodList
+    case "collectexpressiontype":
+      self = .collectExpressionType
     case "all":
-        self = .all
+      self = .all
     default:
-        throw ArgumentConversionError.unknown(value: argument)
+      throw ArgumentConversionError.unknown(value: argument)
     }
   }
 }

--- a/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
@@ -56,10 +56,16 @@ final class StressTestOperation: Operation {
 
   private let process: ProcessRunner
 
-  init(file: String, rewriteMode: RewriteMode, limit: Int?, part: (Int, of: Int), compilerArgs: [String], executable: String) {
+  init(file: String, rewriteMode: RewriteMode, requests: [RequestKind]?, conformingMethodTypes: [String]?, limit: Int?, part: (Int, of: Int), compilerArgs: [String], executable: String) {
     var stressTesterArgs = ["--format", "json", "--page", "\(part.0)/\(part.of)", "--rewrite-mode", rewriteMode.rawValue]
     if let limit = limit {
       stressTesterArgs += ["--limit", String(limit)]
+    }
+    if let requests = requests {
+      stressTesterArgs += requests.flatMap { ["--request", $0.rawValue] }
+    }
+    if let types = conformingMethodTypes {
+      stressTesterArgs += types.flatMap { ["--type-list-item", $0] }
     }
 
     self.file = file

--- a/SourceKitStressTester/Tests/StressTesterToolTests/StressTesterToolTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/StressTesterToolTests.swift
@@ -56,6 +56,9 @@ class StressTesterToolTests: XCTestCase {
 
     let validRequest2: [String] = [stressTesterPath, "--request", "CURSORINFO"] + validSuffix
     XCTAssertNoThrow(try StressTesterTool(arguments: validRequest2).parse())
+
+    let validRequest3: [String] = [stressTesterPath, "--type-list-item", "s:SQ", "--type-list-item", "s:SH"] + validSuffix
+    XCTAssertNoThrow(try StressTesterTool(arguments: validRequest3).parse())
   }
 
   override func setUp() {


### PR DESCRIPTION
Also add support for controlling (via environment variables)  which rewrite modes and requests the wrapper should invoke the stress tester with, and which protocol USRs the ConformingMethodList request should conform to.