### PR TITLE
[SourceKitStressTester] Add an environment variable to control max concurrent workers

### DIFF
--- a/SourceKitStressTester/Sources/SwiftCWrapper/FailFastOperationQueue.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/FailFastOperationQueue.swift
@@ -18,11 +18,16 @@ public final class FailFastOperationQueue<Item: Operation> {
   private let operations: [Item]
   private let completionHandler: (Item, Int, Int) -> Bool
 
-  init(operations: [Item], maxWorkers: Int = ProcessInfo.processInfo.activeProcessorCount,
+  init(operations: [Item], maxWorkers: Int? = nil,
        completionHandler: @escaping (Item, Int, Int) -> Bool) {
     self.operations = operations
     self.completionHandler = completionHandler
-    queue.maxConcurrentOperationCount = maxWorkers
+    let processorCount = ProcessInfo.processInfo.activeProcessorCount
+    if let maxWorkers = maxWorkers, maxWorkers < processorCount {
+      queue.maxConcurrentOperationCount = maxWorkers
+    } else {
+      queue.maxConcurrentOperationCount = processorCount
+    }
   }
 
   func waitUntilFinished() {

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -26,10 +26,11 @@ struct SwiftCWrapper {
   let conformingMethodTypes: [String]?
   let ignoreIssues: Bool
   let issueManager: IssueManager?
+  let maxJobs: Int?
   let failFast: Bool
   let suppressOutput: Bool
 
-  init(swiftcArgs: [String], swiftcPath: String, stressTesterPath: String, astBuildLimit: Int?, rewriteModes: [RewriteMode]?, requestKinds: [RequestKind]?, conformingMethodTypes: [String]?, ignoreIssues: Bool, issueManager: IssueManager?, failFast: Bool, suppressOutput: Bool) {
+  init(swiftcArgs: [String], swiftcPath: String, stressTesterPath: String, astBuildLimit: Int?, rewriteModes: [RewriteMode]?, requestKinds: [RequestKind]?, conformingMethodTypes: [String]?, ignoreIssues: Bool, issueManager: IssueManager?, maxJobs: Int?, failFast: Bool, suppressOutput: Bool) {
     self.arguments = swiftcArgs
     self.swiftcPath = swiftcPath
     self.stressTesterPath = stressTesterPath
@@ -41,6 +42,7 @@ struct SwiftCWrapper {
     self.rewriteModes = rewriteModes ?? [.none, .concurrent, .insideOut]
     self.requestKinds = requestKinds ?? [.cursorInfo, .rangeInfo, .codeComplete, .collectExpressionType]
     self.conformingMethodTypes = conformingMethodTypes
+    self.maxJobs = maxJobs
   }
 
   var swiftFiles: [String] {
@@ -82,7 +84,7 @@ struct SwiftCWrapper {
       progress = nil
     }
 
-    let queue = FailFastOperationQueue(operations: operations) { operation, completed, total -> Bool in
+    let queue = FailFastOperationQueue(operations: operations, maxWorkers: maxJobs) { operation, completed, total -> Bool in
       let message = "\(operation.file) (\(operation.summary)): \(operation.status.name)"
       progress?.update(percent: completed * 100 / total, text: message)
       return operation.status.isPassed

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapperTool.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapperTool.swift
@@ -39,6 +39,8 @@ public struct SwiftCWrapperTool {
     let requestKindsEnv = EnvOption("SK_STRESS_REQUESTS", type: [RequestKind].self)
     /// Non-default space-separated list of protocol USRs to use for the ConformingMethodList request
     let conformingMethodTypesEnv = EnvOption("SK_STRESS_CONFORMING_METHOD_TYPES", type: [String].self)
+    /// Limit the number of jobs
+    let maxJobsEnv = EnvOption("SK_STRESS_MAX_JOBS", type: Int.self)
 
     // IssueManager params:
     /// Non-default path to the json file containing expected failures
@@ -61,6 +63,7 @@ public struct SwiftCWrapperTool {
     let rewriteModes = try rewriteModesEnv.get(from: environment)
     let requestKinds = try requestKindsEnv.get(from: environment)
     let conformingMethodTypes = try conformingMethodTypesEnv.get(from: environment)
+    let maxJobs = try maxJobsEnv.get(from: environment)
 
     var issueManager: IssueManager? = nil
     if let expectedFailuresPath = try expectedFailuresPathEnv.get(from: environment),
@@ -82,6 +85,7 @@ public struct SwiftCWrapperTool {
                                 conformingMethodTypes: conformingMethodTypes,
                                 ignoreIssues: ignoreIssues,
                                 issueManager: issueManager,
+                                maxJobs: maxJobs,
                                 failFast: true,
                                 suppressOutput: suppressOutput)
     return try wrapper.run()


### PR DESCRIPTION
The wrapper will now set the `OperationQueue`'s `maxConcurrentOperationCount` to be the smaller of `SK_STRESS_MAX_JOBS` (if set) or the number of active processors.