### PR TITLE
[SourceKitStressTester] Add support for reporting and dumping sourcekitd's responses to a file

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -88,7 +88,7 @@ struct SourceKitDocument {
     return response
   }
 
-  func rangeInfo(offset: Int, length: Int) throws -> SourceKitdResponse {
+  func rangeInfo(offset: Int, length: Int) throws -> (RequestInfo, SourceKitdResponse) {
     let request = SourceKitdRequest(uid: .request_RangeInfo)
 
     request.addParameter(.key_SourceFile, value: file)
@@ -113,10 +113,10 @@ struct SourceKitDocument {
       }
     }
 
-    return response
+    return (info, response)
   }
 
-  func cursorInfo(offset: Int) throws -> SourceKitdResponse {
+  func cursorInfo(offset: Int) throws -> (RequestInfo, SourceKitdResponse) {
     let request = SourceKitdRequest(uid: .request_CursorInfo)
 
     request.addParameter(.key_SourceFile, value: file)
@@ -148,11 +148,11 @@ struct SourceKitDocument {
       }
     }
 
-    return response
+    return (info, response)
   }
 
   func semanticRefactoring(actionKind: SourceKitdUID, actionName: String,
-                           offset: Int, newName: String? = nil) throws -> SourceKitdResponse {
+                           offset: Int, newName: String? = nil) throws -> (RequestInfo, SourceKitdResponse) {
     let request = SourceKitdRequest(uid: .request_SemanticRefactoring)
     guard let converter = self.converter else { fatalError("didn't call open?") }
 
@@ -171,10 +171,10 @@ struct SourceKitDocument {
     let response = try sendWithTimeout(request, info: info)
     try throwIfInvalid(response, request: info)
 
-    return response
+    return (info, response)
   }
 
-  func codeComplete(offset: Int) throws -> SourceKitdResponse {
+  func codeComplete(offset: Int) throws -> (RequestInfo, SourceKitdResponse) {
     let request = SourceKitdRequest(uid: .request_CodeComplete)
 
     request.addParameter(.key_SourceFile, value: file)
@@ -187,10 +187,10 @@ struct SourceKitDocument {
     let response = try sendWithTimeout(request, info: info)
     try throwIfInvalid(response, request: info)
 
-    return response
+    return (info, response)
   }
 
-  func typeContextInfo(offset: Int) throws -> SourceKitdResponse {
+  func typeContextInfo(offset: Int) throws -> (RequestInfo, SourceKitdResponse) {
     let request = SourceKitdRequest(uid: .request_TypeContextInfo)
 
     request.addParameter(.key_SourceFile, value: file)
@@ -203,10 +203,10 @@ struct SourceKitDocument {
     let response = try sendWithTimeout(request, info: info)
     try throwIfInvalid(response, request: info)
 
-    return response
+    return (info, response)
   }
 
-  func conformingMethodList(offset: Int, typeList: [String]) throws -> SourceKitdResponse {
+  func conformingMethodList(offset: Int, typeList: [String]) throws -> (RequestInfo, SourceKitdResponse) {
     let request = SourceKitdRequest(uid: .request_ConformingMethodList)
 
     request.addParameter(.key_SourceFile, value: file)
@@ -222,10 +222,10 @@ struct SourceKitDocument {
     let response = try sendWithTimeout(request, info: info)
     try throwIfInvalid(response, request: info)
 
-    return response
+    return (info, response)
   }
 
-  func collectExpressionType() throws -> SourceKitdResponse {
+  func collectExpressionType() throws -> (RequestInfo, SourceKitdResponse) {
     let request = SourceKitdRequest(uid: .request_CollectExpressionType)
 
     request.addParameter(.key_SourceFile, value: file)
@@ -237,7 +237,7 @@ struct SourceKitDocument {
     let response = try sendWithTimeout(request, info: info)
     try throwIfInvalid(response, request: info)
 
-    return response
+    return (info, response)
   }
 
   mutating func replaceText(offset: Int, length: Int, text: String) throws -> (SourceFileSyntax, SourceKitdResponse) {

--- a/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
@@ -20,9 +20,9 @@ final class StressTestOperation: Operation {
     /// Indicates the operation was cancelled
     case cancelled
     /// Indicates the operation was executed and no issues were found
-    case passed
+    case passed([SourceKitResponseData])
     /// Indicates the operation was executed and issues were found
-    case failed(SourceKitError)
+    case failed(SourceKitError, [SourceKitResponseData])
     /// Indicates the operation was executed, but the stress tester itself failed
     case errored(status: Int32, arguments: [String])
 
@@ -56,7 +56,7 @@ final class StressTestOperation: Operation {
 
   private let process: ProcessRunner
 
-  init(file: String, rewriteMode: RewriteMode, requests: [RequestKind]?, conformingMethodTypes: [String]?, limit: Int?, part: (Int, of: Int), compilerArgs: [String], executable: String) {
+  init(file: String, rewriteMode: RewriteMode, requests: [RequestKind]?, conformingMethodTypes: [String]?, limit: Int?, part: (Int, of: Int), reportResponses: Bool, compilerArgs: [String], executable: String) {
     var stressTesterArgs = ["--format", "json", "--page", "\(part.0)/\(part.of)", "--rewrite-mode", rewriteMode.rawValue]
     if let limit = limit {
       stressTesterArgs += ["--limit", String(limit)]
@@ -66,6 +66,9 @@ final class StressTestOperation: Operation {
     }
     if let types = conformingMethodTypes {
       stressTesterArgs += types.flatMap { ["--type-list-item", $0] }
+    }
+    if reportResponses {
+      stressTesterArgs += ["--report-responses"]
     }
 
     self.file = file
@@ -85,16 +88,37 @@ final class StressTestOperation: Operation {
     }
 
     let result = process.run()
-
-    if result.status == EXIT_SUCCESS {
-      status = .passed
-    } else if isCancelled {
+    if isCancelled {
       status = .cancelled
-    } else if let message = StressTesterMessage(from:result.stdout), case .detected(let sourceKitError) = message {
-      status = .failed(sourceKitError)
+    } else if let (error, responses) = parseMessages(result.stdout) {
+      if result.status == EXIT_SUCCESS {
+        status = .passed(responses)
+      } else if let error = error {
+        status = .failed(error, responses)
+      } else {
+        status = .errored(status: result.status, arguments: process.process.arguments ?? [])
+      }
     } else {
       status = .errored(status: result.status, arguments: process.process.arguments ?? [])
     }
+  }
+
+  private func parseMessages(_ data: Data) -> (error: SourceKitError?, responses: [SourceKitResponseData])? {
+    let terminator = UInt8(ascii: "\n")
+    var sourceKitError: SourceKitError? = nil
+    var sourceKitResponses = [SourceKitResponseData]()
+
+    for data in data.split(separator: terminator, omittingEmptySubsequences: true) {
+      guard let message = StressTesterMessage(from: data) else { return nil }
+      switch message {
+      case .detected(let error):
+        guard sourceKitError == nil else { return nil }
+        sourceKitError = error
+      case .produced(let responseData):
+        sourceKitResponses.append(responseData)
+      }
+    }
+    return (sourceKitError, sourceKitResponses)
   }
 
   override func cancel() {

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapperTool.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapperTool.swift
@@ -41,6 +41,8 @@ public struct SwiftCWrapperTool {
     let conformingMethodTypesEnv = EnvOption("SK_STRESS_CONFORMING_METHOD_TYPES", type: [String].self)
     /// Limit the number of jobs
     let maxJobsEnv = EnvOption("SK_STRESS_MAX_JOBS", type: Int.self)
+    /// Dump sourcekitd's responses to the supplied path
+    let dumpResponsesPathEnv = EnvOption("SK_STRESS_DUMP_RESPONSES_PATH", type: String.self)
 
     // IssueManager params:
     /// Non-default path to the json file containing expected failures
@@ -64,6 +66,7 @@ public struct SwiftCWrapperTool {
     let requestKinds = try requestKindsEnv.get(from: environment)
     let conformingMethodTypes = try conformingMethodTypesEnv.get(from: environment)
     let maxJobs = try maxJobsEnv.get(from: environment)
+    let dumpResponsesPath = try dumpResponsesPathEnv.get(from: environment)
 
     var issueManager: IssueManager? = nil
     if let expectedFailuresPath = try expectedFailuresPathEnv.get(from: environment),
@@ -86,6 +89,7 @@ public struct SwiftCWrapperTool {
                                 ignoreIssues: ignoreIssues,
                                 issueManager: issueManager,
                                 maxJobs: maxJobs,
+                                dumpResponsesPath: dumpResponsesPath,
                                 failFast: true,
                                 suppressOutput: suppressOutput)
     return try wrapper.run()


### PR DESCRIPTION
This is controlled via the `--report-responses` option to `sk-stress-test`, which then prints the responses to stdout, and via `SK_STRESS_DUMP_RESPONSES_PATH`, which causes `sk-swiftc-wrapper` to write them out to the provided path.