### PR TITLE
[5.1][SourceKitStressTester] Fix-up sk-swiftc-wrapper test input to match the output of sk-stress-test

### DIFF
--- a/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
@@ -96,13 +96,18 @@ final class StressTestOperation: Operation {
       } else if let error = error {
         status = .failed(error, responses)
       } else {
+        // A non-successful exit code with no error produced-> stress tester failure
         status = .errored(status: result.status, arguments: process.process.arguments ?? [])
       }
     } else {
+      // Non-empty unparseable output -> treat this as a stress tester failure
       status = .errored(status: result.status, arguments: process.process.arguments ?? [])
     }
   }
 
+  /// Parses the given data as a sequence of newline-separated, JSON-encoded `StressTesterMessage`s.
+  ///
+  /// - returns: A tuple of the detected `SourceKitError` (if one was produced) and a possibly-empty list of `SourceKitReponseData`s. If the input data was non-empty and couldn't be parsed, or if more than one detected error was produced, returns nil.
   private func parseMessages(_ data: Data) -> (error: SourceKitError?, responses: [SourceKitResponseData])? {
     let terminator = UInt8(ascii: "\n")
     var sourceKitError: SourceKitError? = nil

--- a/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
+++ b/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
@@ -214,14 +214,14 @@ class SwiftCWrapperToolTests: XCTestCase {
       .appendingPathComponent("invocations.txt", isDirectory: false)
       .path
     errorJson = """
-      {"message": "detected", "error": {
-        "error": "timedOut",
-        "request": {
-          "document": {"path":"\(testFilePath!)"},
-          "offset": 5,
-          "args": ["\(testFilePath!)"],
-          "request": "cursorInfo"
-        }
+      {"message": "detected", "error": {\
+        "error": "timedOut",\
+        "request": {\
+          "document": {"path":"\(testFilePath!)"},\
+          "offset": 5,\
+          "args": ["\(testFilePath!)"],\
+          "request": "cursorInfo"\
+        }\
       }}
       """
 


### PR DESCRIPTION
`sk-stress-test` with `--format json` uses newlines as separators between separate JSON-encoded messages, but one of the tests mocking its output included newlines within a message, causing it fail to parse.