### PR TITLE
[SourceKitStressTester] Use the correct source state when making CodeComplete requests and refactor the ActionGenerators

### DIFF
--- a/SourceKitStressTester/Sources/Common/CollectionExtensions.swift
+++ b/SourceKitStressTester/Sources/Common/CollectionExtensions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -19,5 +19,17 @@ extension Collection {
       return start..<end
     }
     return (0..<pieces).map {piece in self[range(of: piece)]}
+  }
+
+  public func divide<T: Equatable>(by comparison: (Element) -> T) -> [SubSequence] {
+    var working = self[...]
+    var result = [SubSequence]()
+    while let first = working.first {
+      let firstValue = comparison(first)
+      let partition = working.prefix{ comparison($0) == firstValue }
+      result.append(partition)
+      working = working.dropFirst(partition.count)
+    }
+    return result
   }
 }

--- a/SourceKitStressTester/Sources/StressTester/Action.swift
+++ b/SourceKitStressTester/Sources/StressTester/Action.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-enum Action {
+enum Action: Equatable {
   case cursorInfo(offset: Int)
   case codeComplete(offset: Int)
   case rangeInfo(offset: Int, length: Int)

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -178,6 +178,9 @@ struct SourceKitDocument {
     let request = SourceKitdRequest(uid: .request_CodeComplete)
 
     request.addParameter(.key_SourceFile, value: file)
+    if let sourceState = sourceState {
+      request.addParameter(.key_SourceText, value: sourceState.source)
+    }
     request.addParameter(.key_Offset, value: offset)
 
     let compilerArgs = request.addArrayParameter(.key_CompilerArgs)
@@ -194,6 +197,9 @@ struct SourceKitDocument {
     let request = SourceKitdRequest(uid: .request_TypeContextInfo)
 
     request.addParameter(.key_SourceFile, value: file)
+    if let sourceState = sourceState {
+      request.addParameter(.key_SourceText, value: sourceState.source)
+    }
     request.addParameter(.key_Offset, value: offset)
 
     let compilerArgs = request.addArrayParameter(.key_CompilerArgs)
@@ -210,6 +216,9 @@ struct SourceKitDocument {
     let request = SourceKitdRequest(uid: .request_ConformingMethodList)
 
     request.addParameter(.key_SourceFile, value: file)
+    if let sourceState = sourceState {
+      request.addParameter(.key_SourceText, value: sourceState.source)
+    }
     request.addParameter(.key_Offset, value: offset)
 
     let expressionTypeList = request.addArrayParameter(.key_ExpressionTypeList)

--- a/SourceKitStressTester/Sources/StressTester/SwiftSyntaxExtensions.swift
+++ b/SourceKitStressTester/Sources/StressTester/SwiftSyntaxExtensions.swift
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+struct SyntaxAncestorIterator: IteratorProtocol {
+  private var node: Syntax
+
+  fileprivate init(_ node: Syntax) {
+      self.node = node
+  }
+
+  mutating func next() -> Syntax? {
+    if let parent = node.parent {
+      node = parent
+      return node
+    }
+    return nil
+  }
+}
+
+struct SyntaxAncestors: Sequence {
+  private let node: Syntax
+
+  fileprivate init(_ node: Syntax) {
+    self.node = node
+  }
+
+  func makeIterator() -> SyntaxAncestorIterator {
+      return SyntaxAncestorIterator(node)
+  }
+}
+
+extension Syntax {
+  var ancestors: SyntaxAncestors {
+    return SyntaxAncestors(self)
+  }
+}
+
+extension TokenSyntax {
+  var isOperator: Bool {
+    switch tokenKind {
+    case .prefixOperator, .postfixOperator, .spacedBinaryOperator, .unspacedBinaryOperator, .equal:
+      return true
+    default:
+      return false
+    }
+  }
+
+  var pieces: (leadingTrivia: String, content: String, trailingTrivia: String) {
+    let text = description.utf8
+    let leadingTrivia = String(text.prefix(leadingTriviaLength.utf8Length))!
+    let content = String(text.dropFirst(leadingTriviaLength.utf8Length).dropLast(trailingTriviaLength.utf8Length))!
+    let trailingTrivia = String(text.suffix(trailingTriviaLength.utf8Length))!
+    return (leadingTrivia, content, trailingTrivia)
+  }
+
+  var isIdentifier: Bool {
+    switch tokenKind {
+    case .identifier: fallthrough
+    case .dollarIdentifier:
+      return true
+    default:
+      return false
+    }
+  }
+
+  var isReference: Bool {
+    guard isIdentifier else { return false }
+    guard let parent = parent else { return false }
+
+    return parent.isExpr || parent.isType
+  }
+
+  var isLiteralExprClose: Bool {
+    switch self.tokenKind {
+    case .rightParen:
+      return parent is TupleExprSyntax
+    case .rightBrace:
+      return parent is ClosureExprSyntax
+    case .rightSquareBracket:
+      return parent is ArrayExprSyntax || parent is DictionaryExprSyntax
+    default:
+      return false
+    }
+  }
+}


### PR DESCRIPTION
This PR contains two changes:
1. Fix the CodeComplete request to include the 'SourceText' parameter so that sourcekitd uses the correct source state if the document has been modified.
2. Refactor the ActionGenerators so that the 'concurrent' and 'insideOut' generators produce 'RangeInfo' requests too. This change also increases the number of locations the generators decide to make other requests at, potentially detecting more issues.