### PR TITLE
[5.1][SourceKitStressTester] Dump responses improvements

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/StressTester.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTester.swift
@@ -140,10 +140,13 @@ struct StressTester {
     case .typeContextInfo:
       var results = [String]()
       response.value.getArray(.key_Results).enumerate { _, result -> Bool in
-        results.append(result.description)
+        let value = result.getDictionary()
+        let sourceText = value.getString(.key_SourceText)
+        let typeName = value.getString(.key_TypeName)
+        results.append("\(sourceText) (\(typeName))")
         return true
       }
-      try handler(SourceKitResponseData(results, for: request))
+      try handler(SourceKitResponseData(results.sorted(), for: request))
     default:
       try handler(SourceKitResponseData([response.value.description], for: request))
     }

--- a/SourceKitStressTester/Sources/SwiftCWrapper/FailFastOperationQueue.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/FailFastOperationQueue.swift
@@ -16,10 +16,10 @@ public final class FailFastOperationQueue<Item: Operation> {
   private let serialQueue = DispatchQueue(label: "\(FailFastOperationQueue.self)")
   private let queue = OperationQueue()
   private let operations: [Item]
-  private let completionHandler: (Item, Int, Int) -> Bool
+  private let completionHandler: (Int, Item, Int, Int) -> Bool
 
   init(operations: [Item], maxWorkers: Int? = nil,
-       completionHandler: @escaping (Item, Int, Int) -> Bool) {
+       completionHandler: @escaping (Int, Item, Int, Int) -> Bool) {
     self.operations = operations
     self.completionHandler = completionHandler
     let processorCount = ProcessInfo.processInfo.activeProcessorCount
@@ -42,7 +42,7 @@ public final class FailFastOperationQueue<Item: Operation> {
 
         self.serialQueue.sync {
           completed += 1
-          if !self.completionHandler(operation, completed, self.operations.count) {
+          if !self.completionHandler(index, operation, completed, self.operations.count) {
             self.cancelAfter(index)
           }
         }

--- a/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
@@ -20,9 +20,9 @@ final class StressTestOperation: Operation {
     /// Indicates the operation was cancelled
     case cancelled
     /// Indicates the operation was executed and no issues were found
-    case passed([SourceKitResponseData])
+    case passed
     /// Indicates the operation was executed and issues were found
-    case failed(SourceKitError, [SourceKitResponseData])
+    case failed(SourceKitError)
     /// Indicates the operation was executed, but the stress tester itself failed
     case errored(status: Int32, arguments: [String])
 
@@ -53,6 +53,7 @@ final class StressTestOperation: Operation {
   let part: (Int, of: Int)
   let mode: RewriteMode
   var status: Status = .unexecuted
+  var responses = [SourceKitResponseData]()
 
   private let process: ProcessRunner
 
@@ -92,9 +93,11 @@ final class StressTestOperation: Operation {
       status = .cancelled
     } else if let (error, responses) = parseMessages(result.stdout) {
       if result.status == EXIT_SUCCESS {
-        status = .passed(responses)
+        status = .passed
+        self.responses = responses
       } else if let error = error {
-        status = .failed(error, responses)
+        status = .failed(error)
+        self.responses = responses
       } else {
         // A non-successful exit code with no error produced-> stress tester failure
         status = .errored(status: result.status, arguments: process.process.arguments ?? [])

--- a/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
+++ b/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
@@ -90,7 +90,7 @@ class SwiftCWrapperToolTests: XCTestCase {
     let third = TestOperation(waitCount: 20)
     let fourth = TestOperation(waitCount: 30)
 
-    FailFastOperationQueue(operations: [first, second, third, fourth], maxWorkers: 2, completionHandler: { finishedOp, _, _ in
+    FailFastOperationQueue(operations: [first, second, third, fourth], maxWorkers: 2, completionHandler: { _, finishedOp, _, _ in
       // cancel later operations when the second operation completes
       return finishedOp !== second
     }).waitUntilFinished()


### PR DESCRIPTION
This PR changes sk-swiftc-wrapper with SK_STRESS_DUMP_RESPONSES set to:
1) Write out responses to disk as its goes rather than at the end to reduce peak memory consumption
2) Sort code completion results to make comparison between runs easier and print a subset of the information in each result to cut down on the file size of the dumped responses.