### PR TITLE
[SourceKitStressTester] Fix nondeterminism in the ordering and existence of dumped sourcekitd responses

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/StressTester.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTester.swift
@@ -89,7 +89,7 @@ struct StressTester {
 
     // Compute the initial state of the source file for this page
     var state = SourceState(rewriteMode: options.rewriteMode, content: source)
-    pages[0..<options.page.index].joined().forEach {
+    pages[..<options.page.index].joined().forEach {
       if case .replaceText(let offset, let length, let text) = $0 {
         state.replace(offset: offset, length: length, with: text)
       }


### PR DESCRIPTION
Updates the response ordering logic to always ignore responses received from StressTestOperations that are at a later position in the operation list than the first StressTestOperation that found a failure. Also fixes a bug where responses from operations that completed out of order were sometimes lost.