### PR TITLE
[SourceKitStressTester] Reference earlier identical entries when dumping sourcekitd responses to a file to cut down on size

### DIFF
--- a/SourceKitStressTester/Sources/Common/StringExtensions.swift
+++ b/SourceKitStressTester/Sources/Common/StringExtensions.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension String {
+  public var stableHash: UInt64 {
+    var hash: UInt64 = 5381
+    for byte in utf8 {
+      hash = 127 * (hash & 0x00ffffffffffffff) + UInt64(byte)
+    }
+    return hash
+  }
+}


### PR DESCRIPTION
With `SK_STRESS_DUMP_RESPONSES` set, output a hash of each dumped response too. If the same response is returned again later, output only its hash. This cuts down the file size considerably, particularly for code completion results.