### PR TITLE
[SourceKitStressTester] Fix ConcurrentRewriteActionGenerator producing a 0-length RangeInfo Action

### DIFF
--- a/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
@@ -77,7 +77,7 @@ class ActionGeneratorTests: XCTestCase {
         XCTAssertTrue(offset >= 0 && offset <= eof)
       case .rangeInfo(let offset, let length):
         XCTAssertTrue(offset >= 0 && offset <= eof)
-        XCTAssertTrue(length >= 0 && offset + length <= eof)
+        XCTAssertTrue(length > 0 && offset + length <= eof)
       case .replaceText(let offset, let length, let text):
         XCTAssertTrue(offset >= 0 && offset <= eof)
         XCTAssertTrue(length >= 0 && offset + length <= eof)


### PR DESCRIPTION
It incorrectly assumed the start token of a range completed by the end token would always be within the same token group (i.e. the same top-level declaration). This is true for all tokens except the last one in the file, which also completes the range of the entire file. Its start token is always
the first token of the first group/top-level declaration.