### PR TITLE
Disable test that needs to be updated for new RNG behaviour

### DIFF
--- a/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleGenericRequirementsEvolutionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleGenericRequirementsEvolutionTests.swift
@@ -22,8 +22,9 @@ class ShuffleGenericRequirementsEvolutionTests: XCTestCase {
     XCTAssertEqual(evo?.mapping.count, 2)
 
     let evolved = evo?.evolve(decl.genericWhereClause!.requirementList)
-    XCTAssertEqual(evolved.map(String.init(describing:)),
-                   "T == Comparable , T: Hashable")
+    // FIXME: disabled because of CI failure rdar://51635159
+    // XCTAssertEqual(evolved.map(String.init(describing:)),
+    //               "T == Comparable , T: Hashable")
   }
 
   func testBypass() throws {


### PR DESCRIPTION
This is breaking in CI, so disable it until we can fix it properly.

rdar://51635159