### PR TITLE
[SourceKitStressTester] Use exact version for swift-package-manager dependency

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .executable(name: "sk-swiftc-wrapper", targets: ["sk-swiftc-wrapper"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.2.0"),
+    .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Cherry-pick #71 to swift-5.0