### PR TITLE
[SourceKitStressTester] Add support to handle filelists in the wrapper's compiler args

### DIFF
--- a/SourceKitStressTester/Sources/Common/DriverFileList.swift
+++ b/SourceKitStressTester/Sources/Common/DriverFileList.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public struct DriverFileList {
+  public let paths: [String]
+
+  public init?(at path: String) {
+    guard path.starts(with: "@") else { return nil }
+    let url = URL(fileURLWithPath: String(path.dropFirst()), isDirectory: false)
+    if let content = try? String(contentsOf: url, encoding: .utf8) {
+      paths = content.split(separator: "\n").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    } else {
+      return nil
+    }
+  }
+}

--- a/SourceKitStressTester/Sources/StressTester/StressTester.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTester.swift
@@ -23,9 +23,9 @@ struct StressTester {
   let connection: SourceKitdService
 
   init(for file: URL, compilerArgs: [String], options: StressTesterOptions) {
-    self.file = file
     self.source = try! String(contentsOf: file, encoding: .utf8)
-    self.compilerArgs = compilerArgs
+    self.file = file
+    self.compilerArgs = compilerArgs.flatMap { DriverFileList(at: $0)?.paths ?? [$0] }
     self.options = options
     self.connection = SourceKitdService()
   }

--- a/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
@@ -127,8 +127,8 @@ public struct StressTesterTool {
     let absoluteFile = URL(fileURLWithPath: arguments.get(file)!.path.asString)
     let args = Array(arguments.get(compilerArgs)!.dropFirst())
 
-    let tester = StressTester(for: absoluteFile, compilerArgs: args, options: options)
     do {
+      let tester = StressTester(for: absoluteFile, compilerArgs: args, options: options)
       if dryRun {
         let tree = try! SyntaxParser.parse(absoluteFile)
         try report(tester.computeStartStateAndActions(from: tree).actions, as: format)


### PR DESCRIPTION
We were previously ignoring source files passed to the driver via file lists.