### PR TITLE
Update swift-evolve for GenericRequirementSyntax

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
@@ -21,22 +21,19 @@ protocol TrailingCommaSyntax: Syntax {
 }
 
 extension FunctionParameterSyntax: TrailingCommaSyntax {}
-extension ConformanceRequirementSyntax: TrailingCommaSyntax {}
-extension SameTypeRequirementSyntax: TrailingCommaSyntax {}
+extension GenericRequirementSyntax: TrailingCommaSyntax {}
 
-// We cannot use Element: TrailingCommaSyntax here because
-// GenericRequirementListSyntax has untyped Syntax elements.
-extension BidirectionalCollection where Element == Syntax {
+extension BidirectionalCollection where Element: TrailingCommaSyntax {
   func withCorrectTrailingCommas(betweenTrivia: Trivia = [.spaces(1)]) -> [Element] {
     var elems: [Element] = []
 
     for elem in dropLast() {
       let newComma = SyntaxFactory.makeCommaToken(trailingTrivia: betweenTrivia)
-      let newElem = (elem as! TrailingCommaSyntax).withTrailingComma(newComma)
+      let newElem = elem.withTrailingComma(newComma)
       elems.append(newElem)
     }
     if let last = last {
-      elems.append((last as! TrailingCommaSyntax).withTrailingComma(nil))
+      elems.append(last.withTrailingComma(nil))
     }
 
     return elems


### PR DESCRIPTION
The syntax tree now explicitly models a common parent type for ConformanceRequirementSyntax and SameTypeRequirementSyntax; update swift-evolve to match. Happily, this actually tightens up a loose type. Fixes rdar://problem/55645250.