### PR TITLE
Refactor the build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,42 +17,34 @@ The tools in this repository can be built in several different ways:
 
 ### Using Swift's build-script
 
-If you want to build the tools to use a locally built sourcekitd and SwiftLang, use the Swift repository's build-script to build and test the stress tester by passing `--swiftsyntax` and the desired tools' flags as extra options. To build and run tests, for example, you would run:
+If you want to build the tools to use a locally built sourcekitd and SwiftLang, use the Swift repository's build-script to build and test the stress tester by passing `--skstresstester`, its dependencies and the desired tools' flags as extra options. To build and run tests, for example, you would run:
 
 ```
-$ ./utils/build-script -t --swiftsyntax --skstresstester
+$ ./utils/build-script -t --llbuild --swiftpm --skstresstester
 ```
 
 ### For local development
 
-For local development you'll first need to download and install a recent [swift.org development snapshot](https://swift.org/download/#snapshots) toolchain. You'll also need to have the [Swift](https://github.com/apple/swift) and [SwiftSyntax](https://github.com/apple/swift-syntax) repositories checked out adjacent to the swift-stress-tester repository in the structure shown below:
-```
-<workspace>/
-swift/
-swift-syntax/
-swift-stress-tester/
-```
-
-Also make sure you've checked out the branch corresponding to the development snapshot you installed (e.g. master for trunk, or swift-5.0-branch for Swift 5.0) in all of these repositories.
+For local development you'll first need to download and install a recent [swift.org development snapshot](https://swift.org/download/#snapshots) toolchain that matches the latest commit on master in the [SwiftSyntax](https://github.com/apple/swift-syntax). This is because the Stress Tester depends on the latest version of SwiftSyntax and SwiftSyntax integrates into the latests version of the compiler.
 
 #### Via Xcode
 
-To generate an Xcode project that's set up correctly, run `build-script-helper.py`, passing the path to the swiftc executable in the downloaded toolchain via the `--swiftc-exec` option, the tool's package name in the `--package-dir` option, and the `generate-xcodeproj` action:
+To generate an Xcode project that's set up correctly, run `build-script-helper.py`, passing the path to the downloaded toolchain via the `--toolchain` option, the tool's package name in the `--package-dir` option, and the `generate-xcodeproj` action:
 ```
-$ ./build-script-helper.py --package-dir SourceKitStressTester --swiftc-exec $TOOLCHAIN_DIR/usr/bin/swiftc generate-xcodeproj
+$ ./build-script-helper.py --package-dir SourceKitStressTester --toolchain $TOOLCHAIN_DIR generate-xcodeproj
 ```
 This will generate `SourceKitStressTester/SourceKitStressTester.xcodeproj`. Open it and select the toolchain you installed from the Xcode > Toolchains menu, before building the `SourceKitStressTester-Package` scheme.
 
 #### Via command line
 
-To build, run `build-script-helper.py`, passing the path to the swiftc executable in the downloaded toolchain via the `--swiftc-exec` option and the tool's package name in the `--package-dir` option:
+To build, run `build-script-helper.py`, passing the path to the downloaded toolchain via the `--toolchain` option and the tool's package name in the `--package-dir` option:
 ```
-$ ./build-script-helper.py --package-dir SourceKitStressTester --swiftc-exec $TOOLCHAIN_DIR/usr/bin/swiftc
+$ ./build-script-helper.py --package-dir SourceKitStressTester --toolchain $TOOLCHAIN_DIR
 ```
 
 To run the tests, repeat the above command, but additionally pass the `test` action:
 ```
-$ ./Utilities/build-script-helper.py --package-dir SourceKitStressTester --swiftc-exec $TOOLCHAIN_DIR/usr/bin/swiftc test
+$ ./Utilities/build-script-helper.py --package-dir SourceKitStressTester --toolchain $TOOLCHAIN_DIR
 ```
 
 ## Running

--- a/SourceKitStressTester/.gitignore
+++ b/SourceKitStressTester/.gitignore
@@ -4,3 +4,5 @@
 /*.xcodeproj
 /*.xcconfig
 /DerivedData
+/Package.resolved
+/.swiftpm

--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -10,6 +10,9 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
+    // FIXME: We should depend on master once master contains all the degybed files
+    .package(url: "https://github.com/apple/swift-syntax.git", .branch("master-gen")),
+
   ],
   targets: [
     .target(
@@ -17,7 +20,7 @@ let package = Package(
       dependencies: ["Utility"]),
     .target(
       name: "StressTester",
-      dependencies: ["Common", "Utility"]),
+      dependencies: ["Common", "Utility", "SwiftSyntax"]),
     .target(
       name: "SwiftCWrapper",
       dependencies: ["Common", "Utility"]),

--- a/SwiftEvolve/.gitignore
+++ b/SwiftEvolve/.gitignore
@@ -2,3 +2,5 @@
 /.build
 /Packages
 /*.xcodeproj
+/Package.resolved
+/.swiftpm

--- a/SwiftEvolve/Package.swift
+++ b/SwiftEvolve/Package.swift
@@ -10,7 +10,9 @@ let package = Package(
         .library(name: "SwiftEvolve", targets: ["SwiftEvolve"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0"))
+        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
+        // FIXME: We should depend on master once master contains all the degybed files
+        .package(url: "https://github.com/apple/swift-syntax.git", .branch("master-gen")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -20,7 +22,7 @@ let package = Package(
             dependencies: ["SwiftEvolve"]),
         .target(
             name: "SwiftEvolve",
-            dependencies: ["Utility"]),
+            dependencies: ["Utility", "SwiftSyntax"]),
         .testTarget(
           name: "SwiftEvolveTests",
           dependencies: ["SwiftEvolve"])


### PR DESCRIPTION
There are two basic shifts in the way the stress tester builds.
1. SwiftSyntax is now a proper SwiftPM dependency and no longer built
   through the build script.
2. Instead of specifying all the executables the build script needs, it
   requires the path to a toolchain in which it will find all necessary
   products itself.

This PR goes hand-in-hand with https://github.com/apple/swift/pull/27580