### PR TITLE
Revert "Revert "Update swift-evolve for GenericRequirementSyntax""

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
@@ -21,22 +21,19 @@ protocol TrailingCommaSyntax: Syntax {
 }
 
 extension FunctionParameterSyntax: TrailingCommaSyntax {}
-extension ConformanceRequirementSyntax: TrailingCommaSyntax {}
-extension SameTypeRequirementSyntax: TrailingCommaSyntax {}
+extension GenericRequirementSyntax: TrailingCommaSyntax {}
 
-// We cannot use Element: TrailingCommaSyntax here because
-// GenericRequirementListSyntax has untyped Syntax elements.
-extension BidirectionalCollection where Element == Syntax {
+extension BidirectionalCollection where Element: TrailingCommaSyntax {
   func withCorrectTrailingCommas(betweenTrivia: Trivia = [.spaces(1)]) -> [Element] {
     var elems: [Element] = []
 
     for elem in dropLast() {
       let newComma = SyntaxFactory.makeCommaToken(trailingTrivia: betweenTrivia)
-      let newElem = (elem as! TrailingCommaSyntax).withTrailingComma(newComma)
+      let newElem = elem.withTrailingComma(newComma)
       elems.append(newElem)
     }
     if let last = last {
-      elems.append((last as! TrailingCommaSyntax).withTrailingComma(nil))
+      elems.append(last.withTrailingComma(nil))
     }
 
     return elems


### PR DESCRIPTION
Re-apply #86  (revert apple/swift-stress-tester#87).
`GenericRequirementSyntax` change has been cherry-picked to `master` in https://github.com/apple/swift/pull/27816.