### PR TITLE
Migrate SwiftEvolve to new struct-based SwiftSyntax API

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/Evolver.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolver.swift
@@ -24,7 +24,7 @@ struct Context {
   @discardableResult
   mutating func enter(_ node: Syntax) -> Bool {
     syntaxPath.append(node.indexInParent)
-    if let node = node as? Decl {
+    if let node = node.asDecl {
       declContext.append(node)
       return true
     }
@@ -34,7 +34,7 @@ struct Context {
   @discardableResult
   mutating func leave(_ node: Syntax) -> Bool {
     syntaxPath.removeLast()
-    if declContext.last == node {
+    if declContext.last.map(Syntax.init) == node {
       declContext.removeLast()
       return true
     }
@@ -61,7 +61,7 @@ public class Evolver: SyntaxRewriter {
 
     // Cast makes this go through the overload with
     // visitPre()/visitAny()/visitPost().
-    return visit(file as Syntax)
+    return visit(Syntax(file))
   }
 
   var recursionGuard: Syntax?

--- a/SwiftEvolve/Sources/SwiftEvolve/Planner.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Planner.swift
@@ -69,16 +69,15 @@ public class Planner<G: RandomNumberGenerator>: SyntaxAnyVisitor {
     context = Context()
     error = nil
 
-    var visitor = self
-    file.walk(&visitor)
-
+    walk(file)
+    
     if let error = error {
       throw error
     }
   }
 
   func makeLocationString(for node: Syntax) -> String {
-    precondition(node.root == self.fileTree,
+    precondition(node.root == Syntax(self.fileTree),
       "querying for location of node of a different tree than the one we started with")
     if includeLineAndColumn {
       return "at \(node.startLocation(converter: locationConverter))"
@@ -111,7 +110,7 @@ public class Planner<G: RandomNumberGenerator>: SyntaxAnyVisitor {
     }
   }
   
-  public func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+  public override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
     guard error == nil else { return .skipChildren }
 
     if context.enter(node) {
@@ -121,7 +120,7 @@ public class Planner<G: RandomNumberGenerator>: SyntaxAnyVisitor {
     return .visitChildren
   }
   
-  public func visitAnyPost(_ node: Syntax) {
+  public override func visitAnyPost(_ node: Syntax) {
     guard error == nil else { return }
 
     if context.leave(node) {

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxDump.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxDump.swift
@@ -47,8 +47,8 @@ struct SyntaxDump: TextOutputStreamable {
 
     let startLoc = node.startLocation(converter: locationConverter)
     write("(")
-    switch node {
-    case let node as TokenSyntax:
+    switch node.asSyntaxEnum {
+    case .token(let node):
       switch node.tokenKind {
       case .identifier(let name):
         write("identifier")

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxTriviaExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxTriviaExtensions.swift
@@ -35,7 +35,7 @@ extension Syntax {
             shouldRewrite: { $0 == ($0.parent?.children.first ?? $0) },
             transform: { $0.withLeadingTrivia(leading($0.leadingTrivia)) }
           ).visit(self)
-        ) as! Self
+        )
       }
     }
   }
@@ -74,7 +74,7 @@ fileprivate class SingleTokenRewriter: SyntaxRewriter {
   let transform: (TokenSyntax) -> TokenSyntax
   
   override func visit(_ token: TokenSyntax) -> Syntax {
-    return transform(token)
+    return Syntax(transform(token))
   }
   
   override func visitAny(_ node: Syntax) -> Syntax? {

--- a/SwiftEvolve/Tests/SwiftEvolveTests/RegressionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/RegressionTests.swift
@@ -28,7 +28,7 @@ class RegressionTests: XCTestCase {
     let evo = ShuffleMembersEvolution(mapping: [])
 
     for node in code.filter(whereIs: MemberDeclListSyntax.self) {
-      let evolved = evo.evolve(node)
+      let evolved = evo.evolve(Syntax(node))
       let evolvedCode = evolved.description
 
       let locs = (0...9).compactMap {
@@ -63,7 +63,7 @@ class RegressionTests: XCTestCase {
 
         XCTAssertThrowsError(
           try SynthesizeMemberwiseInitializerEvolution(
-            for: decl.members.members, in: dc, using: &unusedRNG
+            for: Syntax(decl.members.members), in: dc, using: &unusedRNG
           ),
           "Should throw when a stored property is in a #if block"
         )
@@ -73,7 +73,7 @@ class RegressionTests: XCTestCase {
 
           XCTAssertNil(
             try SynthesizeMemberwiseInitializerEvolution(
-              for: (ifConfig.clauses.first!.elements as! MemberDeclListSyntax),
+              for: (ifConfig.clauses.first!.elements),
               in: dc, using: &unusedRNG
             ),
             "Should not try to synthesize an init() inside an #if"
@@ -98,7 +98,7 @@ class RegressionTests: XCTestCase {
 
         XCTAssertNoThrow(
           try SynthesizeMemberwiseInitializerEvolution(
-            for: decl.members.members, in: dc, using: &unusedRNG
+            for: Syntax(decl.members.members), in: dc, using: &unusedRNG
           ),
           "Should not throw when properties are only non-stored"
         )
@@ -108,7 +108,7 @@ class RegressionTests: XCTestCase {
 
           XCTAssertNil(
             try SynthesizeMemberwiseInitializerEvolution(
-              for: (ifConfig.clauses.first!.elements as! MemberDeclListSyntax),
+              for: (ifConfig.clauses.first!.elements),
               in: dc, using: &unusedRNG
             ),
             "Should not try to synthesize an init() inside an #if"
@@ -134,7 +134,7 @@ class RegressionTests: XCTestCase {
 
         XCTAssertNoThrow(
           try SynthesizeMemberwiseInitializerEvolution(
-            for: decl.members.members, in: dc, using: &unusedRNG
+            for: Syntax(decl.members.members), in: dc, using: &unusedRNG
           ),
           "Should not throw when there's an explicit init"
         )
@@ -144,7 +144,7 @@ class RegressionTests: XCTestCase {
 
           XCTAssertNil(
             try SynthesizeMemberwiseInitializerEvolution(
-              for: (ifConfig.clauses.first!.elements as! MemberDeclListSyntax),
+              for: (ifConfig.clauses.first!.elements),
               in: dc, using: &unusedRNG
             ),
             "Should not try to synthesize an init() inside an #if"

--- a/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleGenericRequirementsEvolutionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleGenericRequirementsEvolutionTests.swift
@@ -16,12 +16,12 @@ class ShuffleGenericRequirementsEvolutionTests: XCTestCase {
     let dc = DeclContext(declarationChain: [code, decl])
 
     let evo = try ShuffleGenericRequirementsEvolution(
-      for: decl.genericWhereClause!.requirementList, in: dc, using: &predictableRNG
+      for: Syntax(decl.genericWhereClause!.requirementList), in: dc, using: &predictableRNG
     )
 
     XCTAssertEqual(evo?.mapping.count, 2)
 
-    let evolved = evo?.evolve(decl.genericWhereClause!.requirementList)
+    let evolved = evo?.evolve(Syntax(decl.genericWhereClause!.requirementList))
     // FIXME: disabled because of CI failure rdar://51635159
     // XCTAssertEqual(evolved.map(String.init(describing:)),
     //               "T == Comparable , T: Hashable")
@@ -38,7 +38,7 @@ class ShuffleGenericRequirementsEvolutionTests: XCTestCase {
 
     XCTAssertThrowsError(
       try ShuffleGenericRequirementsEvolution(
-        for: decl.genericWhereClause!, in: dc, using: &predictableRNG
+        for: Syntax(decl.genericWhereClause!), in: dc, using: &predictableRNG
       )
     ) { error in
       XCTAssertEqual(error as? EvolutionError, EvolutionError.unsupported)

--- a/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleMembersEvolutionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleMembersEvolutionTests.swift
@@ -18,7 +18,7 @@ class ShuffleMembersEvolutionTests: XCTestCase {
     let decl = code.filter(whereIs: EnumDeclSyntax.self).first!
     let dc = DeclContext(declarationChain: [code, decl])
     let evo = try ShuffleMembersEvolution(
-      for: decl.members.members, in: dc, using: &predictableRNG
+      for: Syntax(decl.members.members), in: dc, using: &predictableRNG
     )
 
     XCTAssertEqual(evo?.mapping.count, 3)

--- a/SwiftEvolve/Tests/SwiftEvolveTests/TestUtils.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/TestUtils.swift
@@ -3,15 +3,15 @@ import SwiftSyntax
 @testable import SwiftEvolve
 import Basic
 
-extension Syntax {
-  func filter<T: Syntax>(whereIs type: T.Type) -> [T] {
-    var visitor = FilterVisitor { $0 is T }
-    walk(&visitor)
-    return visitor.passing as! [T]
+extension SyntaxProtocol {
+  func filter<T: SyntaxProtocol>(whereIs type: T.Type) -> [T] {
+    let visitor = FilterVisitor { $0.is(T.self) }
+    visitor.walk(self)
+    return visitor.passing.map { $0.as(T.self)! }
   }
 }
 
-struct FilterVisitor: SyntaxAnyVisitor {
+class FilterVisitor: SyntaxAnyVisitor {
   let predicate: (Syntax) -> Bool
   var passing: [Syntax] = []
 
@@ -19,7 +19,7 @@ struct FilterVisitor: SyntaxAnyVisitor {
     self.predicate = predicate
   }
 
-  mutating func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+  override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
     if predicate(node) { passing.append(node) }
     return .visitChildren
   }


### PR DESCRIPTION
Migrate SwiftEvolve to the new struct-based API of SwiftSyntax. This change still has some rough edges because we are using the internal properties `_syntaxNode` and `_asConcreteType`, but I’d like to get this in to unblock CI.

Smoothing out these edges can be done in conjunction with a potential evolution of SwiftSyntax, should we decide that it’s useful to expose these types publicly.