### PR TITLE
Fix compile warnings in SwiftEvolve

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/LinearCongruentialGenerator.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/LinearCongruentialGenerator.swift
@@ -16,7 +16,7 @@
 // -----------------------------------------------------------------------------
 
 // Copied from StdlibUnittest/StdlibCoreExtras.swift
-@_fixed_layout
+@frozen
 public struct LinearCongruentialGenerator: RandomNumberGenerator {
 
   @usableFromInline

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxDump.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxDump.swift
@@ -40,9 +40,9 @@ struct SyntaxDump: TextOutputStreamable {
       write(" ")
       write(url?.lastPathComponent ?? "<unknown>")
       write(":")
-      write("\(loc.line)")
+      write(loc.line.map(String.init) ?? "<unknown>")
       write(":")
-      write("\(loc.column)")
+      write(loc.column.map(String.init) ?? "<unknown>")
     }
 
     let startLoc = node.startLocation(converter: locationConverter)

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -82,6 +82,9 @@ extension DeclWithParameters {
 
 extension SourceLocation: CustomStringConvertible {
   public var description: String {
+    let file = self.file ?? "<unknown>"
+    let line = self.line.map(String.init) ?? "<unknown>"
+    let column = self.column.map(String.init) ?? "<unknown>"
     return "\(file):\(line):\(column)"
   }
 }


### PR DESCRIPTION
This fixes the compile warnings that show up when building SwiftEvolve with a recent Swift compiler.