### PR TITLE
Update example invocation of build-script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The tools in this repository can be built in several different ways:
 If you want to build the tools to use a locally built sourcekitd and SwiftLang, use the Swift repository's build-script to build and test the stress tester by passing `--skstresstester`, its dependencies and the desired tools' flags as extra options. To build and run tests, for example, you would run:
 
 ```
-$ ./utils/build-script -t --llbuild --swiftpm --skstresstester
+$ ./swift/utils/build-script --test --skip-build-benchmark --skip-test-cmark --skip-test-swift --install-swift --llbuild --install-llbuild --skip-test-llbuild --swiftpm --install-swiftpm --skip-test-swiftpm --skstresstester --swiftevolve --release
 ```
 
 ### For local development


### PR DESCRIPTION
This way it is actually able to build the stress tester.

I have decided to build a release variant of everything in the example because it’s faster to use a release compiler. Whoever is using the command will most likely be smart enough to remove it, if they want a debug version of the stress tester.