### PR TITLE
Make the stress tester and SwiftEvolve depend on SwiftPM's master branch

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .executable(name: "sk-swiftc-wrapper", targets: ["sk-swiftc-wrapper"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
+    .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
     // FIXME: We should depend on master once master contains all the degybed files
     .package(url: "https://github.com/apple/swift-syntax.git", .branch("master-gen")),
 
@@ -17,13 +17,13 @@ let package = Package(
   targets: [
     .target(
       name: "Common",
-      dependencies: ["Utility"]),
+      dependencies: ["TSCUtility"]),
     .target(
       name: "StressTester",
-      dependencies: ["Common", "Utility", "SwiftSyntax"]),
+      dependencies: ["Common", "TSCUtility", "SwiftSyntax"]),
     .target(
       name: "SwiftCWrapper",
-      dependencies: ["Common", "Utility"]),
+      dependencies: ["Common", "TSCUtility"]),
 
     .target(
       name: "sk-stress-test",

--- a/SourceKitStressTester/Sources/Common/Message.swift
+++ b/SourceKitStressTester/Sources/Common/Message.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import Basic
+import TSCBasic
 
 public protocol Message: Codable, CustomStringConvertible {}
 

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -295,7 +295,7 @@ struct SourceKitDocument {
     // FIXME: We don't supply a valid new name for initializer calls for local
     // rename requests. Ignore these errors for now.
     if response.isError, !response.description.contains("does not match the arity of the old name") {
-      throw SourceKitError.failed(.errorResponse, request: request, response: response.description.chomp())
+      throw SourceKitError.failed(.errorResponse, request: request, response: response.description.spm_chomp())
     }
   }
 

--- a/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
@@ -12,8 +12,8 @@
 
 import Foundation
 import Common
-import Utility
-import Basic
+import TSCUtility
+import TSCBasic
 import SwiftSyntax
 
 public struct StressTesterTool {
@@ -124,7 +124,7 @@ public struct StressTesterTool {
       }
     }
 
-    let absoluteFile = URL(fileURLWithPath: arguments.get(file)!.path.asString)
+    let absoluteFile = URL(fileURLWithPath: arguments.get(file)!.path.pathString)
     let args = Array(arguments.get(compilerArgs)!.dropFirst())
 
     do {

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -12,9 +12,9 @@
 
 import Common
 import Foundation
-import func Utility.createProgressBar
-import protocol Utility.ProgressBarProtocol
-import Basic
+import class TSCUtility.PercentProgressAnimation
+import protocol TSCUtility.ProgressAnimationProtocol
+import TSCBasic
 
 struct SwiftCWrapper {
   let arguments: [String]
@@ -90,10 +90,10 @@ struct SwiftCWrapper {
     guard !operations.isEmpty else { return swiftcResult.status }
 
     // Run the operations, reporting progress
-    let progress: ProgressBarProtocol?
+    let progress: ProgressAnimationProtocol?
     if !suppressOutput {
-      progress = createProgressBar(forStream: stderrStream, header: "Stress testing SourceKit...")
-      progress?.update(percent: 0, text: "Scheduling \(operations.count) operations")
+      progress = PercentProgressAnimation(stream: stderrStream, header: "Stress testing SourceKit...")
+      progress?.update(step: 0, total: operations.count, text: "Scheduling \(operations.count) operations")
     } else {
       progress = nil
     }
@@ -109,7 +109,7 @@ struct SwiftCWrapper {
 
     let queue = FailFastOperationQueue(operations: operations, maxWorkers: maxJobs) { index, operation, completed, total -> Bool in
       let message = "\(operation.file) (\(operation.summary)): \(operation.status.name)"
-      progress?.update(percent: completed * 100 / total, text: message)
+      progress?.update(step: completed, total: total, text: message)
       orderingHandler?.complete(operation.responses, at: index, setLast: !operation.status.isPassed)
       operation.responses.removeAll()
       return operation.status.isPassed

--- a/SourceKitStressTester/Sources/sk-stress-test/main.swift
+++ b/SourceKitStressTester/Sources/sk-stress-test/main.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 import StressTester
-import Basic
+import TSCBasic
 
 let stressTester = StressTesterTool(arguments: CommandLine.arguments)
 

--- a/SourceKitStressTester/Sources/sk-swiftc-wrapper/main.swift
+++ b/SourceKitStressTester/Sources/sk-swiftc-wrapper/main.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 import SwiftCWrapper
-import Basic
+import TSCBasic
 
 let wrapper = SwiftCWrapperTool(arguments: CommandLine.arguments,
                                 environment: ProcessInfo.processInfo.environment)

--- a/SwiftEvolve/Package.swift
+++ b/SwiftEvolve/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "SwiftEvolve", targets: ["SwiftEvolve"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
+        .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
         // FIXME: We should depend on master once master contains all the degybed files
         .package(url: "https://github.com/apple/swift-syntax.git", .branch("master-gen")),
     ],
@@ -22,7 +22,7 @@ let package = Package(
             dependencies: ["SwiftEvolve"]),
         .target(
             name: "SwiftEvolve",
-            dependencies: ["Utility", "SwiftSyntax"]),
+            dependencies: ["TSCUtility", "SwiftSyntax"]),
         .testTarget(
           name: "SwiftEvolveTests",
           dependencies: ["SwiftEvolve"])

--- a/SwiftEvolve/Sources/SwiftEvolve/CommandLine.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/CommandLine.swift
@@ -14,8 +14,8 @@
 ///
 // -----------------------------------------------------------------------------
 
-import Utility
-import Basic
+import TSCUtility
+import TSCBasic
 
 // MARK: Argument parsing
 
@@ -74,7 +74,7 @@ extension SwiftEvolveTool.Step {
     let files: PositionalArgument<[PathArgument]>
     
     init() {
-      parser = Utility.ArgumentParser(usage: usage, overview: overview)
+      parser = ArgumentParser(usage: usage, overview: overview)
       rulesFile = parser.add(option: "--rules", kind: PathArgument.self,
                              usage: "<PATH> JSON specification of plan generation rules")
       seed = parser.add(option: "--seed", kind: UInt64.self,
@@ -119,7 +119,7 @@ extension SwiftEvolveTool.Step: CustomStringConvertible {
       return options.arguments(with: ["--seed", String(seed)])
       
     case let .evolve(planFile: planFile, options: options):
-      return options.arguments(with: ["--plan", planFile.asString])
+      return options.arguments(with: ["--plan", planFile.pathString])
       
     case let .exit(code: status):
       return ["exit", String(status)]
@@ -135,7 +135,7 @@ extension SwiftEvolveTool.Step.Options {
   fileprivate func arguments(with stageArgs: [String]) -> [String] {
     var args = [command] + stageArgs
     if let rulesFile = rulesFile {
-      args += ["--rules", rulesFile.asString]
+      args += ["--rules", rulesFile.pathString]
     }
     if replace {
       args += ["--replace"]
@@ -143,7 +143,7 @@ extension SwiftEvolveTool.Step.Options {
     if verbose {
       args += ["--verbose"]
     }
-    args += files.map { $0.asString }
+    args += files.map { $0.pathString }
     return args
   }
 }

--- a/SwiftEvolve/Sources/SwiftEvolve/SwiftEvolveTool.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SwiftEvolveTool.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 import SwiftSyntax
-import Basic
+import TSCBasic
 
 public class SwiftEvolveTool {
   enum Step: Hashable {
@@ -137,12 +137,9 @@ extension SwiftEvolveTool {
       let evolved = evolver.evolve(in: parsed, at: URL(file))
 
       if options.replace {
-        try withExtendedLifetime(
-          TemporaryFile(
-            dir: file.parentDirectory, prefix: "", suffix: file.basename,
-            deleteOnClose: true
-          )
-        ) { tempFile in
+        try withTemporaryFile(dir: file.parentDirectory, prefix: "",
+                          suffix: file.basename,
+                          deleteOnClose: true) { tempFile in
           tempFile.fileHandle.write(evolved.description)
           
           _ = try withErrorContext(
@@ -186,7 +183,7 @@ extension SwiftEvolveTool {
 
 extension URL {
   init(_ path: AbsolutePath) {
-    self.init(fileURLWithPath: path.asString)
+    self.init(fileURLWithPath: path.pathString)
   }
 }
 

--- a/SwiftEvolve/Tests/SwiftEvolveTests/CommandLineTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/CommandLineTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import SwiftEvolve
-import Basic
+import TSCBasic
 
 class CommandLineTests: XCTestCase {
   func file(named name: String) -> AbsolutePath {

--- a/SwiftEvolve/Tests/SwiftEvolveTests/TestUtils.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/TestUtils.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftSyntax
 @testable import SwiftEvolve
-import Basic
+import TSCBasic
 
 extension SyntaxProtocol {
   func filter<T: SyntaxProtocol>(whereIs type: T.Type) -> [T] {


### PR DESCRIPTION
After this goes through, we can switch to using SwiftPM as a local dependency (as opposed to fetching it from GitHub) and using a unified build for SwiftSyntax.