### PR TITLE
Make the stress tester and SwiftEvolve depend on SwiftSyntax/master

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
     // FIXME: We should depend on master once master contains all the degybed files
-    .package(url: "https://github.com/apple/swift-syntax.git", .branch("master-gen")),
+    .package(url: "https://github.com/apple/swift-syntax.git", .branch("master")),
 
   ],
   targets: [

--- a/SwiftEvolve/Package.swift
+++ b/SwiftEvolve/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
         // FIXME: We should depend on master once master contains all the degybed files
-        .package(url: "https://github.com/apple/swift-syntax.git", .branch("master-gen")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .branch("master")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
SwiftSyntax's `master` branch now contains all generated files. So depend on it instead of the temporary `master-gen` branch.