### PR TITLE
Update test to assert an error if --rules flag is passed twice

### DIFF
--- a/SwiftEvolve/Tests/SwiftEvolveTests/CommandLineTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/CommandLineTests.swift
@@ -61,18 +61,10 @@ class CommandLineTests: XCTestCase {
         verbose: false
       ))
     )
-    
-    XCTAssertEqual(
-      try SwiftEvolveTool.Step(arguments: ["exec-path", "--rules=rules.json", "--rules=other.json", "file1.swift"]),
-      .seed(options: .init(
-        command: "exec-path",
-        files: [file(named: "file1.swift")],
-        rulesFile: file(named: "other.json"),
-        replace: false,
-        verbose: false
-      ))
-    )
 
+    XCTAssertThrowsError(
+      try SwiftEvolveTool.Step(arguments: ["exec-path", "--rules=rules.json", "--rules=other.json", "file1.swift"])
+    )
   }
   
   func testReplace() throws {


### PR DESCRIPTION
The updated version of the argument parser from SwiftPM throws an error
instead of using the second flag.

I got the tests failing by this because the cross-PR-testing bot did not actually check out https://github.com/apple/swift-stress-tester/pull/97 since I posted the test comment on the main Swift repository too early.