### PR TITLE
Remove @testable imports in the stress tester and make all requirements public

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/Action.swift
+++ b/SourceKitStressTester/Sources/StressTester/Action.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-enum Action: Equatable {
+public enum Action: Equatable {
   case cursorInfo(offset: Int)
   case codeComplete(offset: Int)
   case rangeInfo(offset: Int, length: Int)
@@ -21,7 +21,7 @@ enum Action: Equatable {
 }
 
 extension Action: CustomStringConvertible {
-  var description: String {
+  public var description: String {
     switch self {
     case .cursorInfo(let offset):
       return "CusorInfo at offset \(offset)"
@@ -45,7 +45,7 @@ extension Action: Codable {
   enum CodingKeys: String, CodingKey {
     case action, offset, length, text
   }
-  enum BaseAction: String, Codable {
+  public enum BaseAction: String, Codable {
     case cursorInfo, codeComplete, rangeInfo, replaceText, typeContextInfo, conformingMethodList, collectExpressionType
   }
 

--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -13,19 +13,19 @@
 import Foundation
 import SwiftSyntax
 
-protocol ActionGenerator {
+public protocol ActionGenerator {
   func generate(for tree: SourceFileSyntax) -> [Action]
 }
 
 extension ActionGenerator {
   /// Entrypoint intended for testing purposes only
-  func generate(for file: URL) -> [Action] {
+  public func generate(for file: URL) -> [Action] {
     let tree = try! SyntaxParser.parse(file)
     return generate(for: tree)
   }
 
   /// Entrypoint intended for testing purposes only
-  func generate(for source: String) -> [Action] {
+  public func generate(for source: String) -> [Action] {
     let tree = try! SyntaxParser.parse(source: source)
     return generate(for: tree)
   }
@@ -102,9 +102,11 @@ extension ActionGenerator {
 
 /// Walks through the provided source files token by token, generating
 /// CursorInfo, RangeInfo, and CodeComplete actions as it goes.
-final class RequestActionGenerator: ActionGenerator {
+public final class RequestActionGenerator: ActionGenerator {
 
-  func generate(for tree: SourceFileSyntax) -> [Action] {
+  public init() {}
+
+  public func generate(for tree: SourceFileSyntax) -> [Action] {
     let collector = ActionTokenCollector()
     let actions: [Action] = [.collectExpressionType] + collector
       .collect(from: tree)
@@ -153,8 +155,10 @@ final class RequestActionGenerator: ActionGenerator {
 
 /// Walks through the provided source files token by token, editing each identifier to be misspelled, and
 /// unbalancing braces and brackets. Each misspelling or removed brace is restored before the next edit.
-final class TypoActionGenerator: ActionGenerator {
-    func generate(for tree: SourceFileSyntax) -> [Action] {
+public final class TypoActionGenerator: ActionGenerator {
+    public init() {}
+
+    public func generate(for tree: SourceFileSyntax) -> [Action] {
         let collector = ActionTokenCollector()
         return collector.collect(from: tree)
             .flatMap { generateActions(for: $0.token) }
@@ -206,9 +210,10 @@ final class TypoActionGenerator: ActionGenerator {
 /// Works through the provided source files generating actions to first remove their
 /// content, and then add it back again token by token. CursorInfo, RangeInfo and
 /// CodeComplete actions are also emitted at applicable locations.
-final class BasicRewriteActionGenerator: ActionGenerator {
+public final class BasicRewriteActionGenerator: ActionGenerator {
+  public init() {}
 
-  func generate(for tree: SourceFileSyntax) -> [Action] {
+  public func generate(for tree: SourceFileSyntax) -> [Action] {
     let collector = ActionTokenCollector()
     let tokens = collector.collect(from: tree)
     return [.replaceText(offset: 0, length: tree.endPosition.utf8Offset, text: "")] +
@@ -232,8 +237,10 @@ final class BasicRewriteActionGenerator: ActionGenerator {
   }
 }
 
-final class ConcurrentRewriteActionGenerator: ActionGenerator {
-  func generate(for tree: SourceFileSyntax) -> [Action] {
+public final class ConcurrentRewriteActionGenerator: ActionGenerator {
+  public init() {}
+
+  public func generate(for tree: SourceFileSyntax) -> [Action] {
     var actions: [Action] = [.replaceText(offset: 0, length: tree.totalLength.utf8Length, text: "")]
     let groups = tree.statements.map { statement -> ActionTokenGroup in
       let collector = ActionTokenCollector()
@@ -296,9 +303,10 @@ final class ConcurrentRewriteActionGenerator: ActionGenerator {
 /// re-introducing it token by token, from the most deeply nested token to the
 /// least. Actions are emitted before and after each inserted token as it is
 /// inserted.
-final class InsideOutRewriteActionGenerator: ActionGenerator {
+public final class InsideOutRewriteActionGenerator: ActionGenerator {
+  public init() {}
 
-  func generate(for tree: SourceFileSyntax) -> [Action] {
+  public func generate(for tree: SourceFileSyntax) -> [Action] {
     var actions: [Action] = [.replaceText(offset: 0, length: tree.totalLength.utf8Length, text: "")]
     let collector = ActionTokenCollector()
     let actionTokens = collector.collect(from: tree)

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -358,12 +358,12 @@ struct SourceKitDocument {
 }
 
 /// Tracks the current state of a source file
-struct SourceState {
-  let mode: RewriteMode
-  var source: String
-  var wasModified: Bool
+public struct SourceState {
+  public let mode: RewriteMode
+  public var source: String
+  public var wasModified: Bool
 
-  init(rewriteMode: RewriteMode, content source: String, wasModified: Bool = false) {
+  public init(rewriteMode: RewriteMode, content source: String, wasModified: Bool = false) {
     self.mode = rewriteMode
     self.source = source
     self.wasModified = wasModified
@@ -371,7 +371,7 @@ struct SourceState {
 
   /// - returns: true if source state changed
   @discardableResult
-  mutating func replace(offset: Int, length: Int, with text: String) -> Bool {
+  public mutating func replace(offset: Int, length: Int, with text: String) -> Bool {
     let bytes = source.utf8
     let prefix = bytes.prefix(upTo: bytes.index(bytes.startIndex, offsetBy: offset))
     let suffix = bytes.suffix(from: bytes.index(bytes.startIndex, offsetBy: offset + length))

--- a/SourceKitStressTester/Sources/StressTester/StressTester.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTester.swift
@@ -15,14 +15,14 @@ import SwiftLang
 import SwiftSyntax
 import Common
 
-struct StressTester {
+public struct StressTester {
   let file: URL
   let source: String
   let compilerArgs: [String]
   let options: StressTesterOptions
   let connection: SourceKitdService
 
-  init(for file: URL, compilerArgs: [String], options: StressTesterOptions) {
+  public init(for file: URL, compilerArgs: [String], options: StressTesterOptions) {
     self.source = try! String(contentsOf: file, encoding: .utf8)
     self.file = file
     self.compilerArgs = compilerArgs.flatMap { DriverFileList(at: $0)?.paths ?? [$0] }
@@ -99,7 +99,7 @@ struct StressTester {
     return (state, page)
   }
 
-  func run() throws {
+  public func run() throws {
     var document = SourceKitDocument(file.path, args: compilerArgs, connection: connection, containsErrors: true)
 
     // compute the actions for the entire tree
@@ -176,13 +176,15 @@ private extension SourceKitdUID {
   static let kind_CompletionContextThisModule = SourceKitdUID(string: "source.codecompletion.context.thismodule")
 }
 
-struct StressTesterOptions {
-  var astBuildLimit: Int? = nil
-  var requests: RequestSet = .all
-  var rewriteMode: RewriteMode = .none
-  var conformingMethodsTypeList = ["s:SQ", "s:SH"] // Equatable and Hashable
-  var responseHandler: ((SourceKitResponseData) throws -> Void)? = nil
-  var page = Page(1, of: 1)
+public struct StressTesterOptions {
+  public init() {}
+
+  public var astBuildLimit: Int? = nil
+  public var requests: RequestSet = .all
+  public var rewriteMode: RewriteMode = .none
+  public var conformingMethodsTypeList = ["s:SQ", "s:SH"] // Equatable and Hashable
+  public var responseHandler: ((SourceKitResponseData) throws -> Void)? = nil
+  public var page = Page(1, of: 1)
 }
 
 public struct RequestSet: OptionSet {

--- a/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
@@ -82,7 +82,7 @@ public struct StressTesterTool {
     return try process(results)
   }
 
-  func parse() throws -> ArgumentParser.Result {
+  public func parse() throws -> ArgumentParser.Result {
     let result = try parser.parse(arguments)
 
     // validate arguments

--- a/SourceKitStressTester/Sources/SwiftCWrapper/ExpectedIssue.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/ExpectedIssue.swift
@@ -12,19 +12,28 @@
 
 import Common
 
-struct ExpectedIssue: Equatable, Codable {
-  let applicableConfigs: Set<String>
-  let issueUrl: String
-  let path: String
-  let modification: String?
-  let issueDetail: IssueDetail
+public struct ExpectedIssue: Equatable, Codable {
+  public let applicableConfigs: Set<String>
+  public let issueUrl: String
+  public let path: String
+  public let modification: String?
+  public let issueDetail: IssueDetail
+
+  public init(applicableConfigs: Set<String>, issueUrl: String, path: String,
+              modification: String?, issueDetail: IssueDetail) {
+    self.applicableConfigs = applicableConfigs
+    self.issueUrl = issueUrl
+    self.path = path
+    self.modification = modification
+    self.issueDetail = issueDetail
+  }
 
   /// Checks if this expected issue matches the given issue
   ///
   /// - parameters:
   ///   - issue: the issue to match against
   /// - returns: true if the issue matches
-  func matches(_ issue: StressTesterIssue) -> Bool {
+  public func matches(_ issue: StressTesterIssue) -> Bool {
     switch issue {
     case .failed(let sourceKitError):
       return matches(sourceKitError.request)
@@ -132,7 +141,7 @@ struct ExpectedIssue: Equatable, Codable {
   }
 }
 
-extension ExpectedIssue {
+public extension ExpectedIssue {
 
   init(matching stressTesterIssue: StressTesterIssue, issueUrl: String, config: String) {
     self.issueUrl = issueUrl
@@ -202,7 +211,7 @@ extension ExpectedIssue {
     case semanticRefactoring(offset: Int?, refactoring: String?)
     case stressTesterCrash(status: Int32?, arguments: String?)
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
       switch try container.decode(RequestBase.self, forKey: .kind) {
       case .editorOpen:
@@ -250,7 +259,7 @@ extension ExpectedIssue {
       }
     }
 
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
       var container = encoder.container(keyedBy: CodingKeys.self)
       switch self {
       case .editorOpen:

--- a/SourceKitStressTester/Sources/SwiftCWrapper/FailFastOperationQueue.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/FailFastOperationQueue.swift
@@ -18,7 +18,7 @@ public final class FailFastOperationQueue<Item: Operation> {
   private let operations: [Item]
   private let completionHandler: (Int, Item, Int, Int) -> Bool
 
-  init(operations: [Item], maxWorkers: Int? = nil,
+  public init(operations: [Item], maxWorkers: Int? = nil,
        completionHandler: @escaping (Int, Item, Int, Int) -> Bool) {
     self.operations = operations
     self.completionHandler = completionHandler
@@ -30,7 +30,7 @@ public final class FailFastOperationQueue<Item: Operation> {
     }
   }
 
-  func waitUntilFinished() {
+  public func waitUntilFinished() {
     let group = DispatchGroup()
     var completed = 0
 

--- a/SourceKitStressTester/Sources/SwiftCWrapper/IssueManager.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/IssueManager.swift
@@ -15,7 +15,7 @@ import Foundation
 
 /// Keeps track of the detected failures and their status (expected/unexpected)
 /// across multiple wrapper invocations
-struct IssueManager {
+public struct IssueManager {
   let activeConfig: String
   let expectedIssuesFile: URL
   let resultsFile: URL

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -16,7 +16,7 @@ import class TSCUtility.PercentProgressAnimation
 import protocol TSCUtility.ProgressAnimationProtocol
 import TSCBasic
 
-struct SwiftCWrapper {
+public struct SwiftCWrapper {
   let arguments: [String]
   let swiftcPath: String
   let stressTesterPath: String
@@ -31,7 +31,7 @@ struct SwiftCWrapper {
   let failFast: Bool
   let suppressOutput: Bool
 
-  init(swiftcArgs: [String], swiftcPath: String, stressTesterPath: String, astBuildLimit: Int?, rewriteModes: [RewriteMode]?, requestKinds: [RequestKind]?, conformingMethodTypes: [String]?, ignoreIssues: Bool, issueManager: IssueManager?, maxJobs: Int?, dumpResponsesPath: String?, failFast: Bool, suppressOutput: Bool) {
+  public init(swiftcArgs: [String], swiftcPath: String, stressTesterPath: String, astBuildLimit: Int?, rewriteModes: [RewriteMode]?, requestKinds: [RequestKind]?, conformingMethodTypes: [String]?, ignoreIssues: Bool, issueManager: IssueManager?, maxJobs: Int?, dumpResponsesPath: String?, failFast: Bool, suppressOutput: Bool) {
     self.arguments = swiftcArgs
     self.swiftcPath = swiftcPath
     self.stressTesterPath = stressTesterPath
@@ -47,7 +47,7 @@ struct SwiftCWrapper {
     self.dumpResponsesPath = dumpResponsesPath
   }
 
-  var swiftFiles: [(String, size: Int)] {
+  public var swiftFiles: [(String, size: Int)] {
     let dependencyPaths = ["/.build/checkouts/", "/Pods/", "/Carthage/Checkouts"]
     return arguments
       .flatMap { DriverFileList(at: $0)?.paths ?? [$0] }
@@ -233,7 +233,7 @@ private struct OrderingBuffer<T> {
   }
 }
 
-enum RequestKind: String, CaseIterable {
+public enum RequestKind: String, CaseIterable {
   case cursorInfo = "CursorInfo"
   case rangeInfo = "RangeInfo"
   case codeComplete = "CodeComplete"
@@ -278,11 +278,11 @@ fileprivate extension TimeInterval {
   }
 }
 
-enum StressTesterIssue: CustomStringConvertible {
+public enum StressTesterIssue: CustomStringConvertible {
   case failed(SourceKitError)
   case errored(status: Int32, file: String, arguments: String)
 
-  var description: String {
+  public var description: String {
     switch self {
     case .failed(let error):
       return String(describing: error)

--- a/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 import XCTest
-@testable import StressTester
+import StressTester
 import SwiftLang
 import Common
 

--- a/SourceKitStressTester/Tests/StressTesterToolTests/StressTesterToolTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/StressTesterToolTests.swift
@@ -12,7 +12,7 @@
 
 import XCTest
 import Common
-@testable import StressTester
+import StressTester
 
 class StressTesterToolTests: XCTestCase {
   var workspace: URL!

--- a/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
+++ b/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@testable import SwiftCWrapper
+import SwiftCWrapper
 import Common
 
 class SwiftCWrapperToolTests: XCTestCase {

--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -108,14 +108,17 @@ def run(args):
 
   if should_run_action("test", args.build_actions):
     print("** Testing %s **" % package_name)
+    test_config = args.config
+    if package_name == 'SwiftEvolve':
+      # Temporary workaround because SwiftEvolve still uses @testable imports
+      test_config = 'debug'
     try:
       invoke_swift(package_dir=args.package_dir,
         swift_exec=args.swift_exec,
         action='test',
         sourcekit_searchpath=sourcekit_searchpath,
-        # note: test uses a different build_dir so it doesn't interfere with the 'build' step's products before install
-        build_dir=os.path.join(args.build_dir, 'test-build'),
-        config='debug',
+        build_dir=args.build_dir,
+        config=test_config,
         verbose=args.verbose)
     except subprocess.CalledProcessError as e:
       printerr('FAIL: Testing %s failed' % package_name)


### PR DESCRIPTION
The `@testable` imports require a full rebuild of the stress tester.

We can avoid that cost if we make all the tested declarations public and remove the `@testable`.