### PR TITLE
Allow depending on local dependencies for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,23 @@ For local development you'll first need to download and install a recent [swift.
 
 To generate an Xcode project that's set up correctly, run `build-script-helper.py`, passing the path to the downloaded toolchain via the `--toolchain` option, the tool's package name in the `--package-dir` option, and the `generate-xcodeproj` action:
 ```
-$ ./build-script-helper.py --package-dir SourceKitStressTester --toolchain $TOOLCHAIN_DIR generate-xcodeproj
+$ ./build-script-helper.py --package-dir SourceKitStressTester --toolchain $TOOLCHAIN_DIR generate-xcodeproj --no-local-deps
 ```
+If you have the [SwiftSyntax](https://github.com/apple/swift-syntax) and [SwiftPM](https://github.com/apple/swift-package-manager) repositories already checked out next to the stress tester's repository, you can omit the `--no-local-deps` option to use the existing checkouts instead of fetching the dependencies using SwiftPM.
+
 This will generate `SourceKitStressTester/SourceKitStressTester.xcodeproj`. Open it and select the toolchain you installed from the Xcode > Toolchains menu, before building the `SourceKitStressTester-Package` scheme.
 
 #### Via command line
 
-To build, run `build-script-helper.py`, passing the path to the downloaded toolchain via the `--toolchain` option and the tool's package name in the `--package-dir` option:
+To build, run `build-script-helper.py`, passing the path to the downloaded toolchain via the `--toolchain` option and the tool's package name in the `--package-dir` option.
 ```
 $ ./build-script-helper.py --package-dir SourceKitStressTester --toolchain $TOOLCHAIN_DIR
 ```
+If you have the [SwiftSyntax](https://github.com/apple/swift-syntax) and [SwiftPM](https://github.com/apple/swift-package-manager) repositories already checked out next to the stress tester's repository, you can omit the `--no-local-deps` option to use the existing checkouts instead of fetching the dependencies using SwiftPM.
 
 To run the tests, repeat the above command, but additionally pass the `test` action:
 ```
-$ ./Utilities/build-script-helper.py --package-dir SourceKitStressTester --toolchain $TOOLCHAIN_DIR
+$ ./Utilities/build-script-helper.py test --package-dir SourceKitStressTester --toolchain $TOOLCHAIN_DIR
 ```
 
 ## Running

--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.1
 
 import PackageDescription
 #if os(Linux)
@@ -19,27 +19,40 @@ let package = Package(
   targets: [
     .target(
       name: "Common",
-      dependencies: ["TSCUtility"]),
+      dependencies: ["TSCUtility"]
+    ),
     .target(
       name: "StressTester",
-      dependencies: ["Common", "TSCUtility", "SwiftSyntax"]),
+      dependencies: ["Common", "TSCUtility", "SwiftSyntax"]
+    ),
     .target(
       name: "SwiftCWrapper",
-      dependencies: ["Common", "TSCUtility"]),
+      dependencies: ["Common", "TSCUtility"]
+    ),
 
     .target(
       name: "sk-stress-test",
-      dependencies: ["StressTester"]),
+      dependencies: ["StressTester"]
+    ),
     .target(
       name: "sk-swiftc-wrapper",
-      dependencies: ["SwiftCWrapper"]),
+      dependencies: ["SwiftCWrapper"]
+    ),
 
     .testTarget(
-        name: "StressTesterToolTests",
-        dependencies: ["StressTester"]),
+      name: "StressTesterToolTests",
+      dependencies: ["StressTester"],
+      // SwiftPM does not get the rpath for XCTests in multiroot packages right (rdar://56793593)
+      // Add the correct rpath here
+      linkerSettings: [.unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "@loader_path/../../../"])]
+    ),
     .testTarget(
       name: "SwiftCWrapperToolTests",
-      dependencies: ["SwiftCWrapper"])
+      dependencies: ["SwiftCWrapper"],
+      // SwiftPM does not get the rpath for XCTests in multiroot packages right (rdar://56793593)
+      // Add the correct rpath here
+      linkerSettings: [.unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "@loader_path/../../../"])]
+    )
   ]
 )
 

--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -1,6 +1,11 @@
 // swift-tools-version:4.2
 
 import PackageDescription
+#if os(Linux)
+import Glibc
+#else
+import Darwin.C
+#endif
 
 let package = Package(
   name: "SourceKitStressTester",
@@ -9,10 +14,7 @@ let package = Package(
     .executable(name: "sk-swiftc-wrapper", targets: ["sk-swiftc-wrapper"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
-    // FIXME: We should depend on master once master contains all the degybed files
-    .package(url: "https://github.com/apple/swift-syntax.git", .branch("master")),
-
+    // See dependencies added below.
   ],
   targets: [
     .target(
@@ -40,3 +42,16 @@ let package = Package(
       dependencies: ["SwiftCWrapper"])
   ]
 )
+
+if getenv("SWIFTCI_USE_LOCAL_DEPS") == nil {
+  // Building standalone.
+  package.dependencies += [
+    .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
+    .package(url: "https://github.com/apple/swift-syntax.git", .branch("master")),
+  ]
+} else {
+  package.dependencies += [
+    .package(path: "../../swiftpm"),
+    .package(path: "../../swift-syntax"),
+  ]
+}

--- a/SwiftEvolve/Package.swift
+++ b/SwiftEvolve/Package.swift
@@ -1,5 +1,4 @@
-// swift-tools-version:4.2
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version:5.1
 
 import PackageDescription
 
@@ -23,13 +22,19 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "swift-evolve",
-            dependencies: ["SwiftEvolve"]),
+            dependencies: ["SwiftEvolve"]
+        ),
         .target(
             name: "SwiftEvolve",
-            dependencies: ["TSCUtility", "SwiftSyntax"]),
+            dependencies: ["TSCUtility", "SwiftSyntax"]
+        ),
         .testTarget(
-          name: "SwiftEvolveTests",
-          dependencies: ["SwiftEvolve"])
+            name: "SwiftEvolveTests",
+            dependencies: ["SwiftEvolve"],
+            // SwiftPM does not get the rpath for XCTests in multiroot packages right (rdar://56793593)
+            // Add the correct rpath here
+            linkerSettings: [.unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "@loader_path/../../../"])]
+        )
     ]
 )
 

--- a/SwiftEvolve/Package.swift
+++ b/SwiftEvolve/Package.swift
@@ -3,6 +3,12 @@
 
 import PackageDescription
 
+#if os(Linux)
+import Glibc
+#else
+import Darwin.C
+#endif
+
 let package = Package(
     name: "SwiftEvolve",
     products: [
@@ -10,9 +16,7 @@ let package = Package(
         .library(name: "SwiftEvolve", targets: ["SwiftEvolve"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
-        // FIXME: We should depend on master once master contains all the degybed files
-        .package(url: "https://github.com/apple/swift-syntax.git", .branch("master")),
+        // See dependencies added below.
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -28,3 +32,16 @@ let package = Package(
           dependencies: ["SwiftEvolve"])
     ]
 )
+
+if getenv("SWIFTCI_USE_LOCAL_DEPS") == nil {
+    // Building standalone.
+    package.dependencies += [
+        .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .branch("master")),
+    ]
+} else {
+    package.dependencies += [
+        .package(path: "../../swiftpm"),
+        .package(path: "../../swift-syntax"),
+    ]
+}

--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -179,6 +179,9 @@ def invoke_swift(package_dir, action, swift_exec, sourcekit_searchpath, build_di
 
   args = [swift_exec, action, '--package-path', package_dir, '-c', config, '--build-path', build_dir] + interleave('-Xswiftc', swiftc_args) + interleave('-Xlinker', linker_args)
 
+  # Tell SwiftSyntax that we are building in a CI environment so that it does
+  # not need to rebuilt if it has already been built before.
+  env['SWIFT_BUILD_SCRIPT_ENVIRONMENT'] = '1'
 
   check_call(args, env=env, verbose=verbose)
 


### PR DESCRIPTION
We don’t need to fetch the dependencies from GitHub if they are already checked out. 

To do this, we tell SwiftSyntax that we are building in a build script environment by passing the environment variable `SWIFT_BUILD_SCRIPT_ENVIRONMENT`. This causes us to link against the dylib instead of the static library.

Linking against dylibs of other packages does not currently work, because SwiftPM is not setting the correct rpath, hence we need to manually specify these rpaths as `@loader_path/../../../`