### PR TITLE
Remove @testable imports in the SwiftEvolve and make all requirements public

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/AnyEvolution.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/AnyEvolution.swift
@@ -18,7 +18,7 @@
 
 import SwiftSyntax
 
-struct AnyEvolution {
+public struct AnyEvolution {
   var value: Evolution
 
   init(_ value: Evolution) {
@@ -31,7 +31,7 @@ struct AnyEvolution {
 }
 
 extension AnyEvolution: CustomStringConvertible {
-  var description: String {
+  public var description: String {
     return String(describing: value)
   }
 }
@@ -44,7 +44,7 @@ extension AnyEvolution: Codable {
     case value
   }
 
-  init(from decoder: Decoder) throws {
+  public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
     let kind = try container.decode(Kind.self, forKey: .kind)
@@ -53,7 +53,7 @@ extension AnyEvolution: Codable {
 
   }
 
-  func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
 
     try container.encode(value.kind, forKey: .kind)

--- a/SwiftEvolve/Sources/SwiftEvolve/CommandLine.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/CommandLine.swift
@@ -31,7 +31,7 @@ enum CommandLineError: Error, CustomStringConvertible {
 }
 
 extension SwiftEvolveTool.Step {
-  init(arguments: [String]) throws {
+  public init(arguments: [String]) throws {
     let command = arguments.first!
     let rest = Array(arguments.dropFirst())
     
@@ -126,7 +126,7 @@ extension SwiftEvolveTool.Step: CustomStringConvertible {
     }
   }
   
-  var description: String {
+  public var description: String {
     return arguments.map { $0.shellEscaped }.joined(separator: " ")
   }
 }

--- a/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
@@ -21,14 +21,14 @@ private func makeName(from declarationChain: [Decl]) -> String {
   return declarationChain.map { $0.name }.joined(separator: ".")
 }
 
-struct DeclContext {
+public struct DeclContext {
   private(set) var name: String
 
   var declarationChain: [Decl] = [] {
     didSet { name = makeName(from: declarationChain) }
   }
 
-  init(declarationChain: [Decl] = []) {
+  public init(declarationChain: [Decl] = []) {
     self.declarationChain = declarationChain
     name = makeName(from: declarationChain)
   }
@@ -64,7 +64,7 @@ struct DeclContext {
 }
 
 extension DeclContext: CustomStringConvertible {
-  var description: String {
+  public var description: String {
     return name
   }
 
@@ -112,7 +112,7 @@ extension DeclContext {
   }
 }
 
-enum AccessLevel: String {
+public enum AccessLevel: String {
   case `private`, `fileprivate`, `internal`, `public`, `open`
 }
 
@@ -137,7 +137,7 @@ extension SyntaxProtocol {
   }
 }
 
-protocol Decl {
+public protocol Decl {
   /// We do the same trick here that SwiftSyntax does with `SyntaxProtocol` and
   /// `Syntax`. Picking the same name that is already used by SyntaxProtocol
   /// means we don't have to reimplement the property in terms of Syntax(self).
@@ -153,7 +153,7 @@ protocol Decl {
   func lookupDirect(_ name: String) -> Decl?
 }
 
-extension Decl {
+public extension Decl {
   var isResilient: Bool { return true }
   var isStored: Bool { return false }
 
@@ -162,7 +162,7 @@ extension Decl {
   }
 }
 
-extension Decl where Self: DeclWithMembers {
+public extension Decl where Self: DeclWithMembers {
   func lookupDirect(_ name: String) -> Decl? {
     for item in members.members {
       guard let member = item.decl.asDecl else { continue }
@@ -174,7 +174,7 @@ extension Decl where Self: DeclWithMembers {
   }
 }
 
-extension Decl where Self: AbstractFunctionDecl {
+public extension Decl where Self: AbstractFunctionDecl {
   func lookupDirect(_ name: String) -> Decl? {
     guard let body = self.body else { return nil }
     for item in body.statements {
@@ -188,11 +188,11 @@ extension Decl where Self: AbstractFunctionDecl {
 }
 
 extension SourceFileSyntax: Decl {
-  var name: String { return "(file)" }
+  public var name: String { return "(file)" }
 
-  var modifiers: ModifierListSyntax? { return nil }
+  public var modifiers: ModifierListSyntax? { return nil }
   
-  func lookupDirect(_ name: String) -> Decl? {
+  public func lookupDirect(_ name: String) -> Decl? {
     for item in statements {
       guard let decl = item.item.asDecl else { continue }
       if decl.name == name {
@@ -204,63 +204,63 @@ extension SourceFileSyntax: Decl {
 }
 
 extension ClassDeclSyntax: Decl {
-  var name: String {
+  public var name: String {
     return identifier.text
   }
 
-  var isResilient: Bool {
+  public var isResilient: Bool {
     return !attributes.contains(named: "_fixed_layout")
   }
 }
 
 extension StructDeclSyntax: Decl {
-  var name: String {
+  public var name: String {
     return identifier.text
   }
 
-  var isResilient: Bool {
+  public var isResilient: Bool {
     return !attributes.contains(named: "_fixed_layout")
   }
 }
 
 extension EnumDeclSyntax: Decl {
-  var name: String {
+  public var name: String {
     return identifier.text
   }
 
-  var isResilient: Bool {
+  public var isResilient: Bool {
     return !attributes.contains(named: "_frozen")
   }
 }
 
 extension ProtocolDeclSyntax: Decl {
-  var name: String {
+  public var name: String {
     return identifier.text
   }
 }
 
 extension ExtensionDeclSyntax: Decl {
-  var name: String {
+  public var name: String {
     return "(extension \(extendedType.typeText))"
   }
 }
 
 extension TypealiasDeclSyntax: Decl {
-  var name: String {
+  public var name: String {
     return identifier.text
   }
   
-  func lookupDirect(_ name: String) -> Decl? {
+  public func lookupDirect(_ name: String) -> Decl? {
     fatalError("Not implemented: \(type(of: self)).lookupDirect(_:)")
   }
 }
 
 extension AssociatedtypeDeclSyntax: Decl {
-  var name: String {
+  public var name: String {
     return identifier.text
   }
   
-  func lookupDirect(_ name: String) -> Decl? {
+  public func lookupDirect(_ name: String) -> Decl? {
     fatalError("Not implemented: \(type(of: self)).lookupDirect(_:)")
   }
 }
@@ -270,7 +270,7 @@ extension FunctionDeclSyntax: Decl {}
 extension InitializerDeclSyntax: Decl {}
 
 extension SubscriptDeclSyntax: Decl {
-  func lookupDirect(_ name: String) -> Decl? {
+  public func lookupDirect(_ name: String) -> Decl? {
     fatalError("Not implemented: \(type(of: self)).lookupDirect(_:)")
   }
 }
@@ -342,7 +342,7 @@ extension VariableDeclSyntax: Decl {
     }
   }
   
-  var name: String {
+  public var name: String {
     let list = boundProperties
     if list.count == 1 { return list.first!.name.text }
     let nameList = list.map { $0.name.text }
@@ -364,7 +364,7 @@ extension VariableDeclSyntax: Decl {
 
   // FIXME: Is isResilient == true correct?
 
-  var isStored: Bool {
+  public var isStored: Bool {
     // FIXME: It's wrong to describe the whole decl as stored or not stored;
     // each individual binding (or, arguably, each individual bound property)
     // is stored or not stored.
@@ -397,7 +397,7 @@ extension VariableDeclSyntax: Decl {
     }
   }
   
-  func lookupDirect(_ name: String) -> Decl? {
+  public func lookupDirect(_ name: String) -> Decl? {
     return nil
   }
 }
@@ -418,7 +418,7 @@ extension EnumCaseElementSyntax {
 }
 
 extension EnumCaseDeclSyntax: Decl {
-  var name: String {
+  public var name: String {
     if elements.count == 1 {
       return elements.first!.name
     }
@@ -427,11 +427,11 @@ extension EnumCaseDeclSyntax: Decl {
     }
   }
 
-  var isStored: Bool {
+  public var isStored: Bool {
     return true
   }
 
-  func lookupDirect(_ name: String) -> Decl? {
+  public func lookupDirect(_ name: String) -> Decl? {
     return nil
   }
 }

--- a/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
@@ -18,7 +18,7 @@
 import SwiftSyntax
 
 /// Errors with recognized meaning for evolution initialization.
-enum EvolutionError: Error {
+public enum EvolutionError: Error {
   /// The evolution does not know how to handle this node. If this is a
   /// prerequisite evolution, the evolution following it cannot be performed.
   case unsupported
@@ -28,7 +28,7 @@ enum EvolutionError: Error {
 /// evolution knows which declarations it can be applied to; to see if it can
 /// be applied to a given declaration, try to create an instance with
 /// `init(for:in:using:)`.
-protocol Evolution: Codable {
+public protocol Evolution: Codable {
   /// Attempts to create a random instance of the given evolution on `node`.
   ///
   /// - Parameter node: The syntax node we're looking to evolve.
@@ -93,14 +93,14 @@ extension Evolution {
     return prereqs + [evo]
   }
 
-  func makePrerequisites<G>(
+  public func makePrerequisites<G>(
     for node: Syntax, in decl: DeclContext, using rng: inout G
   ) throws -> [Evolution] where G: RandomNumberGenerator {
     return []
   }
 }
 
-extension AnyEvolution {
+public extension AnyEvolution {
   enum Kind: String, Codable, CaseIterable {
     case shuffleMembers
     case synthesizeMemberwiseInitializer
@@ -120,15 +120,19 @@ extension AnyEvolution {
 }
 
 /// An evolution which rearranges the members of a type.
-struct ShuffleMembersEvolution: Evolution {
+public struct ShuffleMembersEvolution: Evolution {
   /// The members to be shuffled. Any indices not in this list should be moved
   /// to the end and kept in the same order.
-  var mapping: [Int]
-  var kind: AnyEvolution.Kind { return .shuffleMembers }
+  public var mapping: [Int]
+  public var kind: AnyEvolution.Kind { return .shuffleMembers }
+
+  public init(mapping: [Int]) {
+    self.mapping = mapping
+  }
 }
 
 /// An evolution which makes an implicit struct initializer explicit.
-struct SynthesizeMemberwiseInitializerEvolution: Evolution {
+public struct SynthesizeMemberwiseInitializerEvolution: Evolution {
   struct StoredProperty: Codable, CustomStringConvertible {
     var name: String
     var type: String
@@ -140,19 +144,19 @@ struct SynthesizeMemberwiseInitializerEvolution: Evolution {
   
   var inits: [[StoredProperty]]
   
-  var kind: AnyEvolution.Kind { return .synthesizeMemberwiseInitializer }
+  public var kind: AnyEvolution.Kind { return .synthesizeMemberwiseInitializer }
 }
 
 /// An evolution which shuffles the constraints in a generic where clause.
-struct ShuffleGenericRequirementsEvolution: Evolution {
-  var mapping: [Int]
-  var kind: AnyEvolution.Kind { return .shuffleGenericRequirements }
+public struct ShuffleGenericRequirementsEvolution: Evolution {
+  public var mapping: [Int]
+  public var kind: AnyEvolution.Kind { return .shuffleGenericRequirements }
 }
 
 // MARK: Implementations
 
 extension ShuffleMembersEvolution {
-  init?<G>(for node: Syntax, in decl: DeclContext, using rng: inout G) throws
+  public init?<G>(for node: Syntax, in decl: DeclContext, using rng: inout G) throws
     where G: RandomNumberGenerator
   {
     guard
@@ -177,7 +181,7 @@ extension ShuffleMembersEvolution {
     self.init(mapping: mapping)
   }
 
-  func makePrerequisites<G>(
+  public func makePrerequisites<G>(
     for node: Syntax, in decl: DeclContext, using rng: inout G
   ) throws -> [Evolution] where G : RandomNumberGenerator {
     return [
@@ -186,7 +190,7 @@ extension ShuffleMembersEvolution {
     ].compactMap { $0 }.flatMap { $0 }
   }
 
-  func evolve(_ node: Syntax) -> Syntax {
+  public func evolve(_ node: Syntax) -> Syntax {
     let members = Array(node.as(MemberDeclListSyntax.self)!)
 
     let inMapping = Set(mapping)
@@ -198,7 +202,7 @@ extension ShuffleMembersEvolution {
 }
 
 extension SynthesizeMemberwiseInitializerEvolution {
-  init?<G>(for node: Syntax, in decl: DeclContext, using rng: inout G) throws
+  public init?<G>(for node: Syntax, in decl: DeclContext, using rng: inout G) throws
     where G : RandomNumberGenerator
   {
     guard let members = node.as(MemberDeclListSyntax.self) else {
@@ -283,7 +287,7 @@ extension SynthesizeMemberwiseInitializerEvolution {
     self.init(inits: inits)
   }
 
-  func evolve(_ node: Syntax) -> Syntax {
+  public func evolve(_ node: Syntax) -> Syntax {
     let members = node.as(MemberDeclListSyntax.self)!
     
     let evolved = inits.reduce(members) { members, properties in
@@ -335,7 +339,7 @@ extension SynthesizeMemberwiseInitializerEvolution {
 }
 
 extension ShuffleGenericRequirementsEvolution {
-  init?<G>(for node: Syntax, in decl: DeclContext, using rng: inout G) throws
+  public init?<G>(for node: Syntax, in decl: DeclContext, using rng: inout G) throws
     where G: RandomNumberGenerator
   {
     guard
@@ -352,7 +356,7 @@ extension ShuffleGenericRequirementsEvolution {
     self.init(mapping: mapping)
   }
 
-  func evolve(_ node: Syntax) -> Syntax {
+  public func evolve(_ node: Syntax) -> Syntax {
     let requirements = Array(node.as(GenericRequirementListSyntax.self)!)
 
     precondition(requirements.count == mapping.count,

--- a/SwiftEvolve/Sources/SwiftEvolve/EvolutionRules.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/EvolutionRules.swift
@@ -19,7 +19,11 @@
 import SwiftSyntax
 
 public struct EvolutionRules {
-  var exclusions: [AnyEvolution.Kind: Set<String>?]
+  public var exclusions: [AnyEvolution.Kind: Set<String>?]
+
+  public init(exclusions: [AnyEvolution.Kind: Set<String>?]) {
+    self.exclusions = exclusions
+  }
 
   func makeAll<G>(
     for node: Syntax, in decl: DeclContext, using rng: inout G
@@ -44,7 +48,7 @@ public struct EvolutionRules {
     }
   }
   
-  func permit(_ kind: AnyEvolution.Kind, forDeclName declName: String) -> Bool {
+  public func permit(_ kind: AnyEvolution.Kind, forDeclName declName: String) -> Bool {
     guard let excludedDeclNames = exclusions[kind, default: []] else {
       // If exclusions[kind] == Optional.some(.none), all decl names are
       // excluded.
@@ -70,7 +74,7 @@ extension EvolutionRules: Decodable {
 }
 
 extension AnyEvolution.Kind: CodingKey, CustomStringConvertible {
-  var description: String {
+  public var description: String {
     return stringValue
   }
 }

--- a/SwiftEvolve/Sources/SwiftEvolve/IO.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/IO.swift
@@ -23,7 +23,7 @@ public enum LogType: Int, Comparable {
     return lhs.rawValue < rhs.rawValue
   }
 
-  static var minimumToPrint = LogType.error
+  public static var minimumToPrint = LogType.error
 }
 
 public func log(type: LogType, _ items: Any..., separator: String = " ", terminator: String = "\n") {

--- a/SwiftEvolve/Sources/SwiftEvolve/SwiftEvolveTool.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SwiftEvolveTool.swift
@@ -19,19 +19,27 @@ import SwiftSyntax
 import TSCBasic
 
 public class SwiftEvolveTool {
-  enum Step: Hashable {
+  public enum Step: Hashable {
     case parse(arguments: [String])
     case seed(options: Options)
     case plan(seed: UInt64, options: Options)
     case evolve(planFile: AbsolutePath, options: Options)
     case exit(code: Int32)
     
-    struct Options: Hashable {
+    public struct Options: Hashable {
       let command: String
       let files: [AbsolutePath]
       let rulesFile: AbsolutePath?
       let replace: Bool
       let verbose: Bool
+
+      public init(command: String, files: [AbsolutePath], rulesFile: AbsolutePath?, replace: Bool, verbose: Bool) {
+        self.command = command
+        self.files = files
+        self.rulesFile = rulesFile
+        self.replace = replace
+        self.verbose = verbose
+      }
     }
   }
   
@@ -60,7 +68,7 @@ extension SwiftEvolveTool.Step {
   }
 }
 
-extension SwiftEvolveTool.Step.Options {
+public extension SwiftEvolveTool.Step.Options {
   func setMinimumLogTypeToPrint() {
     LogType.minimumToPrint = verbose ? .debug : .info
   }

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -18,7 +18,7 @@
 import SwiftSyntax
 import Foundation
 
-protocol DeclWithMembers: DeclSyntaxProtocol {
+public protocol DeclWithMembers: DeclSyntaxProtocol {
   var members: MemberDeclBlockSyntax { get }
   func withMembers(_ newChild: MemberDeclBlockSyntax?) -> Self
 }
@@ -29,50 +29,50 @@ extension EnumDeclSyntax: DeclWithMembers {}
 extension ProtocolDeclSyntax: DeclWithMembers {}
 extension ExtensionDeclSyntax: DeclWithMembers {}
 
-protocol DeclWithParameters: DeclSyntaxProtocol {
+public protocol DeclWithParameters: DeclSyntaxProtocol {
   var baseName: String { get }
   
   var parameters: ParameterClauseSyntax { get }
   func withParameters(_ parameters: ParameterClauseSyntax?) -> Self
 }
 
-protocol AbstractFunctionDecl: DeclWithParameters {
+public protocol AbstractFunctionDecl: DeclWithParameters {
   var body: CodeBlockSyntax? { get }
   func withBody(_ body: CodeBlockSyntax?) -> Self
 }
 
 extension InitializerDeclSyntax: AbstractFunctionDecl {
-  var baseName: String { return "init" }
+  public var baseName: String { return "init" }
 }
 
 extension FunctionDeclSyntax: AbstractFunctionDecl {
-  var baseName: String {
+  public var baseName: String {
     return identifier.text
   }
 
-  var parameters: ParameterClauseSyntax {
+  public var parameters: ParameterClauseSyntax {
     return signature.input
   }
 
-  func withParameters(_ parameters: ParameterClauseSyntax?) -> FunctionDeclSyntax {
+  public func withParameters(_ parameters: ParameterClauseSyntax?) -> FunctionDeclSyntax {
     return withSignature(signature.withInput(parameters))
   }
 }
 
 extension SubscriptDeclSyntax: DeclWithParameters {
-  var baseName: String { return "subscript" }
+  public var baseName: String { return "subscript" }
 
-  var parameters: ParameterClauseSyntax {
+  public var parameters: ParameterClauseSyntax {
     return indices
   }
 
-  func withParameters(_ parameters: ParameterClauseSyntax?) -> SubscriptDeclSyntax {
+  public func withParameters(_ parameters: ParameterClauseSyntax?) -> SubscriptDeclSyntax {
     return withIndices(parameters)
   }
 }
 
 extension DeclWithParameters {
-  var name: String {
+  public var name: String {
     let parameterNames = parameters.parameterList.map { param in
       "\(param.firstName?.text ?? "_"):"
     }
@@ -209,7 +209,7 @@ fileprivate class TokenTextFormatter: SyntaxVisitor {
   }
 }
 
-extension SyntaxCollection {
+public extension SyntaxCollection {
   var first: Element? {
     return self.first(where:{_ in true})
   }

--- a/SwiftEvolve/Tests/SwiftEvolveTests/CommandLineTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/CommandLineTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import SwiftEvolve
+import SwiftEvolve
 import TSCBasic
 
 class CommandLineTests: XCTestCase {

--- a/SwiftEvolve/Tests/SwiftEvolveTests/RegressionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/RegressionTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftSyntax
-@testable import SwiftEvolve
+import SwiftEvolve
 
 class RegressionTests: XCTestCase {
   var unusedRNG = UnusedGenerator()

--- a/SwiftEvolve/Tests/SwiftEvolveTests/RulesTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/RulesTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import SwiftEvolve
+import SwiftEvolve
 
 class RulesTests: XCTestCase {
   let sharedRules = EvolutionRules(exclusions: [

--- a/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleGenericRequirementsEvolutionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleGenericRequirementsEvolutionTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import SwiftSyntax
 import SwiftLang
-@testable import SwiftEvolve
+import SwiftEvolve
 
 class ShuffleGenericRequirementsEvolutionTests: XCTestCase {
   var predictableRNG = PredictableGenerator(values: 1..<16)

--- a/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleMembersEvolutionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleMembersEvolutionTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftSyntax
-@testable import SwiftEvolve
+import SwiftEvolve
 
 class ShuffleMembersEvolutionTests: XCTestCase {
   var predictableRNG = PredictableGenerator(values: 0..<16)

--- a/SwiftEvolve/Tests/SwiftEvolveTests/TestUtils.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/TestUtils.swift
@@ -1,6 +1,6 @@
 import XCTest
 import SwiftSyntax
-@testable import SwiftEvolve
+import SwiftEvolve
 import TSCBasic
 
 extension SyntaxProtocol {

--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -120,10 +120,6 @@ def run(args):
 
   if should_run_action("test", args.build_actions):
     print("** Testing %s **" % package_name)
-    test_config = args.config
-    if package_name == 'SwiftEvolve':
-      # Temporary workaround because SwiftEvolve still uses @testable imports
-      test_config = 'debug'
     try:
       invoke_swift(package_dir=args.package_dir,
         swift_exec=args.swift_exec,
@@ -132,7 +128,7 @@ def run(args):
         sourcekit_searchpath=sourcekit_searchpath,
         build_dir=args.build_dir,
         multiroot_data_file=args.multiroot_data_file,
-        config=test_config,
+        config=args.config,
         env=env,
         verbose=args.verbose)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
The `@testable` imports require a full rebuild of SwiftEvolve.

We can avoid that cost if we make all the tested declarations public and remove the `@testable`.