### PR TITLE
[SourceKitStressTester] Add check the completion results include the name at the completion location in the original source file

### DIFF
--- a/SourceKitStressTester/Sources/Common/Message.swift
+++ b/SourceKitStressTester/Sources/Common/Message.swift
@@ -62,7 +62,7 @@ public enum SourceKitError: Error {
 }
 
 public enum SourceKitErrorReason: String, Codable {
-  case errorResponse, errorTypeInResponse, errorDeserializingSyntaxTree, sourceAndSyntaxTreeMismatch
+  case errorResponse, errorTypeInResponse, errorDeserializingSyntaxTree, sourceAndSyntaxTreeMismatch, missingExpectedResult
 }
 
 public enum RequestInfo {
@@ -370,6 +370,8 @@ extension SourceKitErrorReason: CustomStringConvertible {
       return "SourceKit returned a response with invalid SyntaxTree data"
     case .sourceAndSyntaxTreeMismatch:
       return "SourceKit returned a syntax tree that doesn't match the expected source"
+    case .missingExpectedResult:
+      return "SourceKit returned a response that didn't contain the expected result"
     }
   }
 }

--- a/SourceKitStressTester/Sources/StressTester/Action.swift
+++ b/SourceKitStressTester/Sources/StressTester/Action.swift
@@ -12,6 +12,9 @@
 
 public enum Action: Equatable {
   case cursorInfo(offset: Int)
+
+  /// If expectedResult is non-nil, the results should contain expectedResult, otherwise the results should
+  /// not be checked.
   case codeComplete(offset: Int, expectedResult: ExpectedResult?)
   case rangeInfo(offset: Int, length: Int)
   case replaceText(offset: Int, length: Int, text: String)

--- a/SourceKitStressTester/Sources/StressTester/Action.swift
+++ b/SourceKitStressTester/Sources/StressTester/Action.swift
@@ -12,7 +12,7 @@
 
 public enum Action: Equatable {
   case cursorInfo(offset: Int)
-  case codeComplete(offset: Int)
+  case codeComplete(offset: Int, expectedResult: ExpectedResult?)
   case rangeInfo(offset: Int, length: Int)
   case replaceText(offset: Int, length: Int, text: String)
   case typeContextInfo(offset: Int)
@@ -25,8 +25,8 @@ extension Action: CustomStringConvertible {
     switch self {
     case .cursorInfo(let offset):
       return "CusorInfo at offset \(offset)"
-    case .codeComplete(let offset):
-      return "CodeComplete at offset \(offset)"
+    case .codeComplete(let offset, let expectedResult):
+      return "CodeComplete at offset \(offset) with expectedResult \(expectedResult?.name.name ?? "None")"
     case .rangeInfo(let from, let length):
       return "RangeInfo from offset \(from) for length \(length)"
     case .replaceText(let from, let length, let text):
@@ -43,7 +43,7 @@ extension Action: CustomStringConvertible {
 
 extension Action: Codable {
   enum CodingKeys: String, CodingKey {
-    case action, offset, length, text
+    case action, offset, length, text, expectedResult
   }
   public enum BaseAction: String, Codable {
     case cursorInfo, codeComplete, rangeInfo, replaceText, typeContextInfo, conformingMethodList, collectExpressionType
@@ -57,7 +57,8 @@ extension Action: Codable {
       self = .cursorInfo(offset: offset)
     case .codeComplete:
       let offset = try container.decode(Int.self, forKey: .offset)
-      self = .codeComplete(offset: offset)
+      let expectedResult = try container.decodeIfPresent(ExpectedResult.self, forKey: .expectedResult)
+      self = .codeComplete(offset: offset, expectedResult: expectedResult)
     case .rangeInfo:
       let offset = try container.decode(Int.self, forKey: .offset)
       let length = try container.decode(Int.self, forKey: .length)
@@ -84,9 +85,10 @@ extension Action: Codable {
     case .cursorInfo(let offset):
       try container.encode(BaseAction.cursorInfo, forKey: .action)
       try container.encode(offset, forKey: .offset)
-    case .codeComplete(let offset):
+    case .codeComplete(let offset, let expectedResult):
       try container.encode(BaseAction.codeComplete, forKey: .action)
       try container.encode(offset, forKey: .offset)
+      try container.encodeIfPresent(expectedResult, forKey: .expectedResult)
     case .rangeInfo(let startOffset, let length):
       try container.encode(BaseAction.rangeInfo, forKey: .action)
       try container.encode(startOffset, forKey: .offset)
@@ -105,5 +107,45 @@ extension Action: Codable {
     case .collectExpressionType:
       try container.encode(BaseAction.collectExpressionType, forKey: .action)
     }
+  }
+}
+
+public struct ExpectedResult: Codable, Equatable {
+  public enum Kind: String, Codable { case reference, call, pattern }
+  public let name: SwiftName
+  public let kind: Kind
+
+  public init(name: SwiftName, kind: Kind) {
+    self.name = name
+    self.kind = kind
+  }
+}
+
+public struct SwiftName: Codable, Equatable {
+  public let base: String
+  public let argLabels: [String]
+  public var name: String {
+    argLabels.isEmpty
+        ? base
+        : "\(base)(\(argLabels.map{ "\($0.isEmpty ? "_" : $0):" }.joined()))"
+  }
+
+  public init?(_ name: String) {
+    if let argStart = name.firstIndex(of: "(") {
+      guard let argEnd = name.firstIndex(of: ")") else { return nil }
+      base = String(name[..<argStart])
+      argLabels = name[name.index(after: argStart)..<argEnd]
+        .split(separator: ":", omittingEmptySubsequences: false)
+        .dropLast()
+        .map{ $0 == "_" ? "" : String($0)}
+    } else {
+      base = name
+      argLabels = []
+    }
+  }
+
+  init(base: String, labels: [String]) {
+    self.base = base
+    self.argLabels = labels.map{ $0 == "_" ? "" : $0 }
   }
 }

--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -450,6 +450,9 @@ private struct ActionToken {
     // FIXME: test dollar identifiers once code completion reports them
     if case .dollarIdentifier = token.tokenKind { return nil }
 
+    // FIXME: completely ignore ifconfig clauses (conditions and code blocks)
+    if token.ancestors.contains(where: { $0.is(IfConfigClauseListSyntax.self) }) { return nil }
+
     guard let parent = token.parent else { return nil }
 
     // Report argument label completions for any arguments other than the first

--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -444,6 +444,8 @@ private struct ActionToken {
       }
   }
 
+  /// A nil result means the results shouldn't be checked, e.g. if the provided token corresponds to the
+  /// name of a newly declared variable.
   static private func expectedResult(for token: TokenSyntax) -> ExpectedResult? {
     guard token.isReference else { return nil }
 

--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -51,7 +51,8 @@ extension ActionGenerator {
     for frontAction in actionToken.frontActions {
       switch frontAction {
       case .codeComplete:
-        actions.append(.codeComplete(offset: contentStart))
+        let expected: ExpectedResult? = withReplaceTexts ? nil : actionToken.frontExpectedResult
+        actions.append(.codeComplete(offset: contentStart, expectedResult: expected))
       case .conformingMethodList:
         actions.append(.conformingMethodList(offset: contentStart))
       case .typeContextInfo:
@@ -83,7 +84,7 @@ extension ActionGenerator {
       case .cursorInfo:
         actions.append(.cursorInfo(offset: contentEnd))
       case .codeComplete:
-        actions.append(.codeComplete(offset: contentEnd))
+        actions.append(.codeComplete(offset: contentEnd, expectedResult: nil))
       case .conformingMethodList:
         actions.append(.conformingMethodList(offset: contentEnd))
       case .typeContextInfo:
@@ -161,7 +162,7 @@ public final class TypoActionGenerator: ActionGenerator {
     public func generate(for tree: SourceFileSyntax) -> [Action] {
         let collector = ActionTokenCollector()
         return collector.collect(from: tree)
-            .flatMap { generateActions(for: $0.token) }
+            .flatMap { generateActions(for: $0) }
     }
 
     private func updateSpelling(_ kind: TokenKind) -> (original: String, new: String)? {
@@ -192,14 +193,15 @@ public final class TypoActionGenerator: ActionGenerator {
         }
     }
 
-    private func generateActions(for token: TokenSyntax) -> [Action] {
+    private func generateActions(for actionToken: ActionToken) -> [Action] {
+        let token = actionToken.token
         guard let spelling = updateSpelling(token.tokenKind), token.presence == .present else { return [] }
         let contentStart = token.positionAfterSkippingLeadingTrivia.utf8Offset
         let contentLength = token.contentLength.utf8Length
         return [
             .replaceText(offset: contentStart, length: contentLength, text: spelling.new),
             .cursorInfo(offset: contentStart),
-            .codeComplete(offset: contentStart + spelling.new.utf8.count),
+            .codeComplete(offset: contentStart + spelling.new.utf8.count, expectedResult: actionToken.frontExpectedResult),
             .typeContextInfo(offset: contentStart + spelling.new.utf8.count),
             .conformingMethodList(offset: contentStart + spelling.new.utf8.count),
             .replaceText(offset: contentStart, length: spelling.new.utf8.count, text: spelling.original)
@@ -417,12 +419,14 @@ private struct ActionToken {
   let rearActions: [SourcePosAction]
   let endedRangeStartTokens: [TokenSyntax]
   let startedRangeEndTokens: [TokenSyntax]
+  let frontExpectedResult: ExpectedResult?
 
   init(_ token: TokenSyntax, atDepth depth: Int, withFrontActions front: [SourcePosAction], withRearActions rear: [SourcePosAction]) {
     self.token = token
     self.depth = depth
     self.frontActions = front
     self.rearActions = rear
+    self.frontExpectedResult = ActionToken.expectedResult(for: token)
 
     var previous: TokenSyntax? = token
     self.endedRangeStartTokens = token.tokenKind == .eof ? [] : token.ancestors
@@ -438,6 +442,87 @@ private struct ActionToken {
         defer { previous = ancestor.lastToken }
         return ancestor.lastToken == previous ? nil : ancestor.lastToken
       }
+  }
+
+  static private func expectedResult(for token: TokenSyntax) -> ExpectedResult? {
+    guard token.isReference else { return nil }
+
+    // FIXME: test dollar identifiers once code completion reports them
+    if case .dollarIdentifier = token.tokenKind { return nil }
+
+    guard let parent = token.parent else { return nil }
+
+    // Report argument label completions for any arguments other than the first
+    if let tupleElem = parent.as(TupleExprElementSyntax.self), tupleElem.label == token {
+      switch tupleElem.parent?.parent?.as(SyntaxEnum.self) {
+      case .functionCallExpr: fallthrough
+      case .subscriptExpr: fallthrough
+      case .expressionSegment:
+        guard tupleElem.indexInParent != 0 else { return nil }
+        return ExpectedResult(name: SwiftName(base: token.textWithoutBackticks + ":", labels: []), kind: .reference)
+      default:
+        return nil
+      }
+    }
+    if let parent = parent.as(IdentifierExprSyntax.self), parent.identifier == token {
+      if let refArgs = parent.declNameArguments {
+        let name = SwiftName(base: token.text, labels: refArgs.arguments.map{ $0.name.text })
+        return ExpectedResult(name: name, kind: .reference)
+      }
+      if let (kind, callArgs) = getParentArgs(of: parent) {
+        let name = SwiftName(base: token.text, labels: callArgs)
+        return ExpectedResult(name: name, kind: kind)
+      }
+    }
+    if let parent = parent.as(MemberAccessExprSyntax.self), parent.name == token {
+      if let refArgs = parent.declNameArguments {
+        let name = SwiftName(base: token.text, labels: refArgs.arguments.map{ $0.name.text })
+        return ExpectedResult(name: name, kind: .reference)
+      }
+      if let (kind, callArgs) = getParentArgs(of: parent) {
+        let name = SwiftName(base: token.text, labels: callArgs)
+        return ExpectedResult(name: name, kind: kind)
+      }
+    }
+    let name = SwiftName(base: token.text, labels: [])
+    return ExpectedResult(name: name, kind: .reference)
+  }
+
+  static func getParentArgs<T:SyntaxProtocol>(of syntax: T) -> (kind: ExpectedResult.Kind, args: [String])? {
+    guard let parent = syntax.parent else { return nil }
+    if let call = parent.as(FunctionCallExprSyntax.self) {
+      // Check for: Bar.foo(instanceOfBar)(x:1)
+      if call.argumentList.count == 1 &&
+         call.argumentList.allSatisfy({$0.label == nil}) {
+        if let outerCall = call.parent?.as(FunctionCallExprSyntax.self),
+           Syntax(outerCall.calledExpression) == parent {
+          // The outer call args correspond to foo if they have any labels. If
+          // they don't have labels we can't actually tell syntactically whether
+          // the outer or inner argument list corresponds to foo. In that case
+          // though reporting the outer argument list is the safer choice as it
+          // can be empty - indicating that foo may have no paramters - while
+          // the inner list always has one argument. If foo has at least one
+          // parameter, the number of unlabelled arguments we report here
+          // doesn't matter, so either list is fine. The logic that matches
+          // the argument list reported here against the actual parameters
+          // reported in the completion result assumes any parameter could be
+          // defaulted or variadic, so with too few arguments the unmatched
+          // params are assumed to be defaulted, and with too many arguments and
+          // at least one parameter, the extras are assumed to be variadic terms
+          // of the last parameter. If foo has no parameters however, there's no
+          // possibly-variadic parameter to match arguments, so it will fail.
+          return (.call, outerCall.argumentList.map{ $0.label?.text ?? "_" })
+        }
+      }
+      let kind: ExpectedResult.Kind
+      if call.ancestors.contains(where: { $0.is(ExpressionPatternSyntax.self) }) {
+        kind = .pattern
+      } else {
+        kind = .call
+      }
+      return (kind, call.argumentList.map{ $0.label?.text ?? "_" })
+    }
+    return nil
   }
 }
 

--- a/SourceKitStressTester/Sources/StressTester/StressTester.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTester.swift
@@ -114,8 +114,8 @@ public struct StressTester {
       switch action {
       case .cursorInfo(let offset):
         try report(document.cursorInfo(offset: offset))
-      case .codeComplete(let offset):
-        try report(document.codeComplete(offset: offset))
+      case .codeComplete(let offset, let expectedResult):
+        try report(document.codeComplete(offset: offset, expectedResult: expectedResult))
       case .rangeInfo(let offset, let length):
         try report(document.rangeInfo(offset: offset, length: length))
       case .replaceText(let offset, let length, let text):

--- a/SourceKitStressTester/Sources/StressTester/SwiftSyntaxExtensions.swift
+++ b/SourceKitStressTester/Sources/StressTester/SwiftSyntaxExtensions.swift
@@ -77,8 +77,14 @@ extension TokenSyntax {
   var isReference: Bool {
     guard isIdentifier else { return false }
     guard let parent = parent else { return false }
+    return parent.is(ExprSyntaxProtocol.self) ||
+      parent.is(TypeSyntaxProtocol.self) ||
+      parent.is(TupleExprElementSyntax.self)
+  }
 
-    return parent.is(ExprSyntaxProtocol.self) || parent.is(TypeSyntaxProtocol.self)
+  var textWithoutBackticks: String {
+    guard text.first == "`" && text.last == "`" else { return text }
+    return String(text.dropFirst().dropLast())
   }
 
   var isLiteralExprClose: Bool {

--- a/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
@@ -64,9 +64,10 @@ class ActionGeneratorTests: XCTestCase {
       ("Foo.foo(fooInstance)(x: 10)", ["Foo", "call:foo(x:)", "fooInstance"]),
 
       // The below foo could be either foo(_:) or foo(_:_:), we can't tell
-      // syntactically so default to the one with fewer args as that will still
-      // the longer one if that's what it ends up being in the completion
-      // results (the extra param will be assumed to be defaulted).
+      // syntactically so default to the outer argument list, as it will match
+      // even if it should have been the inner argument list due to the
+      // incomplete information the matching logic has (it has to assume any
+      // parameter could be defaulted or variadic).
       ("Foo.foo(fooInstance)(10, 20)", ["Foo", "call:foo(_:_:)", "fooInstance"]),
       ("Foo.foo(fooInstance)()", ["Foo", "call:foo", "fooInstance"]),
       ("let (x, y) = (a, b)", ["a", "b"]),

--- a/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
@@ -50,6 +50,105 @@ class ActionGeneratorTests: XCTestCase {
     """)
   }
 
+  func testCompletionExpectedResults() {
+    typealias TestCase = (source: String, expected: [String])
+    let cases: [TestCase] = [
+      ("foo(x: 10)", ["call:foo(x:)"]),
+      ("foo(45)", ["call:foo(_:)"]),
+      ("foo.bar(first, x: 10)", ["foo", "call:bar(_:x:)", "first", "x:"]),
+      ("foo.bar(x:_:)", ["foo", "bar(x:_:)"]),
+
+      // FIXME: code completion doesn't complete compound name references
+      (".foo(x:y:z:)", ["foo(x:y:z:)"/*, "x", "y", "z"*/]),
+      (".foo(1, 2, other: 5)", ["call:foo(_:_:other:)", "other:"]),
+      ("Foo.foo(fooInstance)(x: 10)", ["Foo", "call:foo(x:)", "fooInstance"]),
+
+      // The below foo could be either foo(_:) or foo(_:_:), we can't tell
+      // syntactically so default to the one with fewer args as that will still
+      // the longer one if that's what it ends up being in the completion
+      // results (the extra param will be assumed to be defaulted).
+      ("Foo.foo(fooInstance)(10, 20)", ["Foo", "call:foo(_:_:)", "fooInstance"]),
+      ("Foo.foo(fooInstance)()", ["Foo", "call:foo", "fooInstance"]),
+      ("let (x, y) = (a, b)", ["a", "b"]),
+      ("if case let .myCase(Int.max, second) = p {}", ["patt:myCase(_:_:)", "Int", "max", "p"]),
+      ("if case let .myCase(.inner(x:foo), second) = p {}", ["patt:myCase(_:_:)", "patt:inner(x:)", "p"]),
+      ("switch x { case .some(2?): break }", ["x", "patt:some(_:)"]),
+
+      // TODO: we don't check operators at the moment
+      ("3 + 4", []),
+      // FIXME: code completion doesn't offer labels after break/continue
+      ("foo: for x in 1...4 { print(x); break foo }", ["call:print(_:)", "x"/*, "foo"*/]),
+
+      // TODO: subscript completions after [
+      ("data[position]", ["data", "position"]),
+      ("data[position, default: 0]", ["data", "position", "default:"]),
+
+      // FIXME: completion doesn't suggest anonymous closure params (e.g. $0)
+      ("$0.first", [/*"$0",*/ "first"]),
+      ("[1,2,4].filter{ $0 == 4 }", ["call:filter"/*, "$0"*/])
+    ]
+
+    for test in cases {
+      let generated = RequestActionGenerator().generate(for: test.source)
+        .compactMap { action -> String? in
+          if case .codeComplete(_, let expected) = action, expected != nil {
+            let type: String
+            switch expected!.kind {
+            case .call:
+              type = "call:"
+            case .pattern:
+              type = "patt:"
+            case .reference:
+              type = ""
+            }
+            return "\(type)\(expected!.name.name)"
+          }
+          return nil
+        }
+      XCTAssertEqual(generated, test.expected)
+    }
+  }
+
+  func testExpectedResultMatcher() {
+    typealias TestCase = (match: ExpectedResult.Kind, of: String, against: String, ignoreArgs: Bool, result: Bool)
+    let cases: [TestCase] = [
+      (match: .reference, of: "myVar", against: "myVar", ignoreArgs: false, result: true),
+      (match: .reference, of: "myVar", against: "MyVar", ignoreArgs: true, result: false),
+      (match: .reference, of: "MyType", against: "MyType", ignoreArgs: true, result: true),
+      (match: .reference, of: "MyType", against: "myType", ignoreArgs: true, result: false),
+      (match: .reference, of: "myLabel:", against: "myLabel:", ignoreArgs: false, result: true),
+      (match: .reference, of: "myLabel:", against: "myLabel", ignoreArgs: false, result: false),
+      (match: .reference, of: "myLabel", against: "myLabel:", ignoreArgs: false, result: false),
+      (match: .call, of: "bar(_:)", against: "bar()", ignoreArgs: false, result: false),
+      (match: .call, of: "bar()", against: "bar(_:)", ignoreArgs: false, result: true),
+      (match: .call, of: "bar(_:)", against: "bar(y:)", ignoreArgs: false, result: false),
+      (match: .call, of: "bar(y:)", against: "bar(y:)", ignoreArgs: false, result: true),
+      (match: .call, of: "bar(y:)", against: "bar(x:_:y:)", ignoreArgs: false, result: true),
+      (match: .call, of: "bar(_:_:_:y:)", against: "bar(x:_:y:)", ignoreArgs: false, result: true),
+      (match: .call, of: "bar(z:)", against: "bar(x:_:y:)", ignoreArgs: false, result: false),
+      (match: .call, of: "bar(x:)", against: "bar(x:_:y:)", ignoreArgs: false, result: true),
+      (match: .call, of: "myFuncTypeVar(_:_:)", against: "myFuncTypeVar", ignoreArgs: true, result: true),
+      (match: .call, of: "myFuncTypeVar(_:_:)", against: "myFuncTypeVar", ignoreArgs: false, result: false),
+      (match: .reference, of: "bar(y:)", against: "bar(y:)", ignoreArgs: false, result: true),
+      (match: .reference, of: "bar(y:)", against: "bar(x:_:y:)", ignoreArgs: false, result: false),
+      (match: .reference, of: "bar", against: "bar(x:_:y:)", ignoreArgs: false, result: true),
+      (match: .reference, of: "Foo(x:)", against: "Foo", ignoreArgs: false, result: false),
+      (match: .call, of: "Foo(x:)", against: "Foo", ignoreArgs: true, result: true),
+      (match: .call, of: "Foo(x:)", against: "Foo", ignoreArgs: false, result: false),
+      (match: .pattern, of: "first(_:)", against: "first(x:y:)", ignoreArgs: false, result: true),
+      (match: .pattern, of: "first", against: "first(x:y:)", ignoreArgs: false, result: true),
+      (match: .pattern, of: "first(_:z:)", against: "first(x:y:)", ignoreArgs: false, result: false),
+      (match: .pattern, of: "first(_:)", against: "first", ignoreArgs: false, result: false),
+      (match: .pattern, of: "first(_:)", against: "first()", ignoreArgs: false, result: true),
+      (match: .pattern, of: "first(_:_:)", against: "first()", ignoreArgs: false, result: true)
+    ]
+
+    for test in cases {
+      let matcher = CompletionMatcher(for: ExpectedResult(name: SwiftName(test.of)!, kind: test.match))
+      XCTAssertEqual(matcher.match(test.against, ignoreArgLabels: test.ignoreArgs), test.result, "comparing \(test.match.rawValue) of \(test.of) against \(test.against) \(test.ignoreArgs ? "ex" : "in")cluding args does not return \(test.result)")
+    }
+  }
+
   func testRewriteActionGenerator() {
     let actions = BasicRewriteActionGenerator().generate(for: testFile)
     verify(actions, rewriteMode: .basic, expectedActionTypes: [.codeComplete, .cursorInfo, .rangeInfo, .conformingMethodList, .typeContextInfo, .collectExpressionType, .replaceText])
@@ -95,7 +194,7 @@ class ActionGeneratorTests: XCTestCase {
       switch action {
       case .cursorInfo(let offset):
         XCTAssertTrue(offset >= 0 && offset <= eof)
-      case .codeComplete(let offset), .conformingMethodList(let offset), .typeContextInfo(let offset):
+      case .codeComplete(let offset, _), .conformingMethodList(let offset), .typeContextInfo(let offset):
         XCTAssertTrue(offset >= 0 && offset <= eof)
       case .rangeInfo(let offset, let length):
         XCTAssertTrue(offset >= 0 && offset <= eof)
@@ -185,7 +284,7 @@ final class ActionMarkup {
         switch action {
         case .cursorInfo(let offset):
           return [(offset, "I")]
-        case .codeComplete(let offset):
+        case .codeComplete(let offset, _):
           return [(offset, "C")]
         case .rangeInfo(let offset, let length):
           return [(offset, "R"), (offset + length, "E")]


### PR DESCRIPTION
Initially only perform this check for identifiers corresponding to a decl reference or argument label.
Also fix a bug where the stress tester recently started printing a description of its json output data rather than the json output itself.

Resolves rdar://problem/56604923