### PR TITLE
Add a dummy LinuxMain.swift to the stress tester

### DIFF
--- a/SourceKitStressTester/Tests/LinuxMain.swift
+++ b/SourceKitStressTester/Tests/LinuxMain.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+// This is a dummpy file to allow running tests of SwiftSyntax on Linux in a 
+// unified build. Running the stress tester on Linux is not supported.
+
+XCTMain({ () -> [XCTestCaseEntry] in
+  return []
+}())


### PR DESCRIPTION
This allows other projects to test in a unified build. Otherwise SwiftPM is complaining about a missing `LinuxMain.swift` file.