### PR TITLE
Adjust for changed SwiftSyntax API

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
@@ -277,7 +277,7 @@ extension SubscriptDeclSyntax: Decl {
 
 extension PatternSyntax {
   var boundIdentifiers: [(name: TokenSyntax, type: TypeSyntax?)] {
-    switch Syntax(self).asSyntaxEnum {
+    switch Syntax(self).as(SyntaxEnum.self) {
     case .identifierPattern(let identifierPattern):
       return [(identifierPattern.identifier, nil)]
 
@@ -372,7 +372,7 @@ extension VariableDeclSyntax: Decl {
       guard let accessor = binding.accessor else {
         return true
       }
-      switch Syntax(accessor).asSyntaxEnum {
+      switch Syntax(accessor).as(SyntaxEnum.self) {
       case .codeBlock(_):
         // There's a computed getter.
         return false

--- a/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
@@ -221,7 +221,7 @@ extension SynthesizeMemberwiseInitializerEvolution {
     var properties: [StoredProperty] = []
 
     for membersItem in members {
-      switch Syntax(membersItem.decl).asSyntaxEnum {
+      switch Syntax(membersItem.decl).as(SyntaxEnum.self) {
       case .ifConfigDecl(let ifConfig):
         if ifConfig.containsStoredMembers {
           // We would need to generate separate inits for each version. Maybe

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxDump.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxDump.swift
@@ -47,7 +47,7 @@ struct SyntaxDump: TextOutputStreamable {
 
     let startLoc = node.startLocation(converter: locationConverter)
     write("(")
-    switch node.asSyntaxEnum {
+    switch node.as(SyntaxEnum.self) {
     case .token(let node):
       switch node.tokenKind {
       case .identifier(let name):

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -130,7 +130,7 @@ extension DeclContext {
 
 extension TypeSyntax {
   func lookup(in context: DeclContext) -> DeclContext? {
-    switch Syntax(self).asSyntaxEnum {
+    switch Syntax(self).as(SyntaxEnum.self) {
     case .simpleTypeIdentifier(let simpleTypeIdentifier):
       return context.lookupUnqualified(simpleTypeIdentifier.name)
     case .memberTypeIdentifier(let memberTypeIdentifier):
@@ -154,7 +154,7 @@ extension TypeSyntax {
   func isFunctionType(in dc: DeclContext) -> Bool {
     let abs = absolute(in: dc)
 
-    switch Syntax(abs).asSyntaxEnum {
+    switch Syntax(abs).as(SyntaxEnum.self) {
     case .functionType(_):
       return true
 


### PR DESCRIPTION
Use `as(SyntaxEnum.self)` instead of `asSyntaxEnum`

This goes hand-in-hand with https://github.com/apple/swift-syntax/pull/168