### PR TITLE
[SourceKitStressTester] Fix stress tester JSON output writing

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
@@ -149,7 +149,8 @@ public struct StressTesterTool {
       stdoutStream <<< String(describing: message) <<< "\n"
     case .json:
       let data = try JSONEncoder().encode(message)
-      stdoutStream <<< data <<< "\n".data(using: .ascii)!
+      stdoutStream.write(data)
+      stdoutStream.write("\n".data(using: .ascii)!)
     }
     stdoutStream.flush()
   }


### PR DESCRIPTION
It looks like the behavior of <<< changed from writing out the data itself to writing out a description of the data at some point. This was causing the stress tester CI job to fail because the wrapper couldn't read the stress tester output (e.g. https://ci.swift.org/job/swift-master-sourcekitd-stress-tester/1487/consoleText)