### PR TITLE
[SwiftEvolve] Add custom casting function to Decl

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
@@ -131,9 +131,16 @@ extension Syntax {
 }
 
 extension SyntaxProtocol {
-  var asDecl: Decl? {
-    // FIXME: We should not rely on `_asConcreteType` here.
-    return Syntax(self)._asConcreteType as? Decl
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// `Decl`. 
+  func `is`(_: Decl.Protocol) -> Bool {
+    return self.as(Decl.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// `Decl`. Otherwise return `nil`.
+  func `as`(_: Decl.Protocol) -> Decl? {
+    return Syntax(self).as(SyntaxProtocol.self) as? Decl
   }
 }
 
@@ -165,7 +172,7 @@ public extension Decl {
 public extension Decl where Self: DeclWithMembers {
   func lookupDirect(_ name: String) -> Decl? {
     for item in members.members {
-      guard let member = item.decl.asDecl else { continue }
+      guard let member = item.decl.as(Decl.self) else { continue }
       if member.name == name {
         return member
       }
@@ -178,7 +185,7 @@ public extension Decl where Self: AbstractFunctionDecl {
   func lookupDirect(_ name: String) -> Decl? {
     guard let body = self.body else { return nil }
     for item in body.statements {
-      guard let decl = item.item.asDecl else { continue }
+      guard let decl = item.item.as(Decl.self) else { continue }
       if decl.name == name {
         return decl
       }
@@ -194,7 +201,7 @@ extension SourceFileSyntax: Decl {
   
   public func lookupDirect(_ name: String) -> Decl? {
     for item in statements {
-      guard let decl = item.item.asDecl else { continue }
+      guard let decl = item.item.as(Decl.self) else { continue }
       if decl.name == name {
         return decl
       }
@@ -446,7 +453,7 @@ extension IfConfigDeclSyntax {
       return members.contains { memberItem in
         if let nestedIfConfig = memberItem.decl.as(IfConfigDeclSyntax.self) {
           return nestedIfConfig.containsStoredMembers
-        } else if let member = memberItem.decl.asDecl {
+        } else if let member = memberItem.decl.as(Decl.self) {
           return member.isStored
         } else {
           return false

--- a/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
@@ -165,7 +165,7 @@ extension ShuffleMembersEvolution {
     let members = Array(membersList)
 
     func shouldShuffleMember(at i: Int) -> Bool {
-      guard let memberDecl = members[i].decl.asDecl else {
+      guard let memberDecl = members[i].decl.as(Decl.self) else {
         // Don't know what this is, so conservatively leave it alone.
         return false
       }
@@ -259,7 +259,7 @@ extension SynthesizeMemberwiseInitializerEvolution {
 
       default:
         // Consistency check: This isn't somehow stored, is it?
-        if let member = membersItem.decl.asDecl {
+        if let member = membersItem.decl.as(Decl.self) {
           assert(!member.isStored, "\(member.name) is a stored non-property???")
         }
 

--- a/SwiftEvolve/Sources/SwiftEvolve/Evolver.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolver.swift
@@ -24,7 +24,7 @@ struct Context {
   @discardableResult
   mutating func enter(_ node: Syntax) -> Bool {
     syntaxPath.append(node.indexInParent)
-    if let node = node.asDecl {
+    if let node = node.as(Decl.self) {
       declContext.append(node)
       return true
     }


### PR DESCRIPTION
This removes the need to use the underscored `_asConcreteType` member and aligns with the new SwiftSyntax API design.

This goes hand-in-hand with https://github.com/apple/swift-syntax/pull/169.