### PR TITLE
Change isExpr to is(ExprSyntaxProtocol.self) etc.

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -473,7 +473,7 @@ private class ActionTokenCollector: SyntaxAnyVisitor {
     if token.isIdentifier {
       return [.cursorInfo, .codeComplete, .typeContextInfo, .conformingMethodList]
     }
-    if !token.isOperator && token.ancestors.contains(where: {($0.isExpr || $0.isType) && $0.firstToken == token}) {
+    if !token.isOperator && token.ancestors.contains(where: {($0.is(ExprSyntaxProtocol.self) || $0.is(TypeSyntaxProtocol.self)) && $0.firstToken == token}) {
       return [.codeComplete, .typeContextInfo, .conformingMethodList]
     }
     if case .contextualKeyword(let text) = token.tokenKind, ["get", "set", "didSet", "willSet"].contains(text) {
@@ -486,7 +486,7 @@ private class ActionTokenCollector: SyntaxAnyVisitor {
     if token.isIdentifier {
       return [.codeComplete, .typeContextInfo, .conformingMethodList]
     }
-    if !token.isOperator && token.ancestors.contains(where: {($0.isExpr || $0.isType) && $0.lastToken == token}) {
+    if !token.isOperator && token.ancestors.contains(where: {($0.is(ExprSyntaxProtocol.self) || $0.is(TypeSyntaxProtocol.self)) && $0.lastToken == token}) {
       return [.codeComplete, .typeContextInfo, .conformingMethodList]
     }
     if case .contextualKeyword(let text) = token.tokenKind, ["get", "set", "didSet", "willSet"].contains(text) {

--- a/SourceKitStressTester/Sources/StressTester/SwiftSyntaxExtensions.swift
+++ b/SourceKitStressTester/Sources/StressTester/SwiftSyntaxExtensions.swift
@@ -78,7 +78,7 @@ extension TokenSyntax {
     guard isIdentifier else { return false }
     guard let parent = parent else { return false }
 
-    return parent.isExpr || parent.isType
+    return parent.is(ExprSyntaxProtocol.self) || parent.is(TypeSyntaxProtocol.self)
   }
 
   var isLiteralExprClose: Bool {


### PR DESCRIPTION
SwiftSyntax removed the `isExpr` etc. properties. The new way to check if a node is an expression is to invoke `is(ExprSyntaxProtocol.self)`.

This goes hand-in-hand with https://github.com/apple/swift-syntax/pull/173