### PR TITLE
Remove extension on SyntaxCollection declaring "first" property

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -208,9 +208,3 @@ fileprivate class TokenTextFormatter: SyntaxVisitor {
     return .skipChildren
   }
 }
-
-public extension SyntaxCollection {
-  var first: Element? {
-    return self.first(where:{_ in true})
-  }
-}


### PR DESCRIPTION
This property is no longer needed when SyntaxCollections conform to `BidirectionalCollection`.

Goes hand-in-hand with https://github.com/apple/swift-syntax/pull/149