### PR TITLE
[SourceKitStressTester] Fix completion expected-result-checking false positive

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -299,14 +299,11 @@ struct SourceKitDocument {
       return expected.kind == .call
     case .kind_DeclVarGlobal, .kind_DeclVarStatic, .kind_DeclVarClass, .kind_DeclVarInstance, .kind_DeclVarParam, .kind_DeclVarLocal:
       // Any variable/property of function type can be called, and looks the
-      // same as a function call as far as the expected rersult is concerned,
+      // same as a function call as far as the expected result is concerned,
       // but it's name won't have any argument labels.
-      // If this result's type has an -> in it somewhere and the expected
-      // result only has empty argument labels (if any), it *may* be in this
-      // category, so match on the base name only.
-      let typeName = result.getString(.key_TypeName)
-      return expected.kind == .call && typeName.contains("->") &&
-        expected.name.argLabels.allSatisfy{ $0.isEmpty }
+      // If the expected result is a call that only has empty argument labels
+      // (if any), it *may* be in this category, so match on the base name only.
+      return expected.kind == .call && expected.name.argLabels.allSatisfy{ $0.isEmpty }
     default:
       return false
     }


### PR DESCRIPTION
For source code like `f(45)`, at the position of `f` we produce an expected completion result with name `f(_:)`. If `f` is a function, code completion produces a result with that name, and we find it. To handle the case where it's a variable of function type, where the name is just `f` rather than `f(_:)`, we were ignoring the argument labels if the completion result was a variable and
its type string contained "->". The type string can be a simple identifier that's a typealias of a function type though, so we were incorrectly reporting an issue in those cases.  This patch changes the logic to match on base name for any variable result if the expected name argument labels are all `_`.