### PR TITLE
[SourceKitStressTester] Don't stress test Xcode project package dependencies

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -518,7 +518,9 @@ public struct CompletionMatcher {
   private func matchesCall(paramLabels: [String]) -> Bool {
     var remainingArgLabels = expected.name.argLabels[...]
 
-    guard !paramLabels.isEmpty else { return remainingArgLabels.isEmpty }
+    guard !paramLabels.isEmpty else {
+      return remainingArgLabels.allSatisfy { $0.isEmpty }
+    }
     for nextParamLabel in paramLabels {
       if nextParamLabel.isEmpty {
         // No label

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -48,7 +48,7 @@ public struct SwiftCWrapper {
   }
 
   public var swiftFiles: [(String, size: Int)] {
-    let dependencyPaths = ["/.build/checkouts/", "/Pods/", "/Carthage/Checkouts"]
+    let dependencyPaths = ["/.build/checkouts/", "/Pods/", "/Carthage/Checkouts", "/SourcePackages/checkouts/"]
     return arguments
       .flatMap { DriverFileList(at: $0)?.paths ?? [$0] }
       .filter { argument in
@@ -242,29 +242,6 @@ public enum RequestKind: String, CaseIterable {
   case collectExpressionType = "CollectExpressionType"
   case format = "Format"
   case all = "All"
-}
-
-struct SwiftFile: Comparable {
-  let file: URL
-
-  init?(_ path: String) {
-    self.file = URL(fileURLWithPath: path, isDirectory: false)
-    guard isSwiftFile && isProjectFile else { return nil }
-  }
-
-  var isSwiftFile: Bool {
-    return file.pathExtension == "swift"
-  }
-
-  var isProjectFile: Bool {
-    // TODO: make this configurable
-    let dependencyPaths = ["/.build/checkouts/", "/Pods/", "/Carthage/Checkouts", "/submodules/"]
-    return dependencyPaths.allSatisfy {!file.path.contains($0)}
-  }
-
-  static func < (lhs: SwiftFile, rhs: SwiftFile) -> Bool {
-    return lhs.file.path < rhs.file.path
-  }
 }
 
 fileprivate extension TimeInterval {

--- a/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
@@ -120,7 +120,8 @@ class ActionGeneratorTests: XCTestCase {
       (match: .reference, of: "myLabel:", against: "myLabel:", ignoreArgs: false, result: true),
       (match: .reference, of: "myLabel:", against: "myLabel", ignoreArgs: false, result: false),
       (match: .reference, of: "myLabel", against: "myLabel:", ignoreArgs: false, result: false),
-      (match: .call, of: "bar(_:)", against: "bar()", ignoreArgs: false, result: false),
+      // C functions don't have any '_' labels in 'against' even if they take arguments.
+      (match: .call, of: "bar(_:)", against: "bar()", ignoreArgs: false, result: true),
       (match: .call, of: "bar()", against: "bar(_:)", ignoreArgs: false, result: true),
       (match: .call, of: "bar(_:)", against: "bar(y:)", ignoreArgs: false, result: false),
       (match: .call, of: "bar(y:)", against: "bar(y:)", ignoreArgs: false, result: true),

--- a/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
+++ b/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
@@ -112,8 +112,18 @@ class SwiftCWrapperToolTests: XCTestCase {
       return wrapper.swiftFiles.map { (file, _) in file }
     }
     let dirPath = workspace.appendingPathComponent("ConfusinglyNamedDir.swift", isDirectory: true).path
+    let blacklistedDir = workspace.appendingPathComponent("SourcePackages/checkouts/SomeSubRepo", isDirectory: true).path
+    let blacklistedFile = workspace.appendingPathComponent("SourcePackages/checkouts/SomeSubRepo/file.swift", isDirectory: false).path
     try! FileManager.default.createDirectory(atPath: dirPath, withIntermediateDirectories: false, attributes: nil)
-    XCTAssertEqual(getSwiftFiles(from: [testFilePath, "/made-up.swift", "unrelated/path", dirPath]), [testFilePath])
+    try! FileManager.default.createDirectory(atPath: blacklistedDir, withIntermediateDirectories: true, attributes: nil)
+    guard FileManager.default.createFile(atPath: blacklistedFile, contents: nil) else { fatalError() }
+
+    XCTAssertEqual(getSwiftFiles(from: [testFilePath,
+                                        "/made-up.swift",
+                                        "unrelated/path",
+                                        blacklistedFile,
+                                        dirPath]),
+                   [testFilePath])
   }
 
   func testEnvParsing() {


### PR DESCRIPTION
Also fix a bug where the expected completion result was present but reported as missing.