### PR TITLE
Fix xcode generation in build helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ $ ./swift/utils/build-script --test --skip-build-benchmark --skip-test-cmark --s
 
 For local development you'll first need to download and install a recent [swift.org development snapshot](https://swift.org/download/#snapshots) toolchain that matches the latest commit on master in the [SwiftSyntax](https://github.com/apple/swift-syntax). This is because the Stress Tester depends on the latest version of SwiftSyntax and SwiftSyntax integrates into the latests version of the compiler.
 
+The toolchain is installed into `/Library/Developer/Toolchains/` if installed for all users. Note that the `$TOOLCHAIN_DIR` variables below should include `/usr` at the end of their path, eg. `TOOLCHAIN_DIR=/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-<...>.xctoolchain/usr`.
+
 #### Via Xcode
 
 To generate an Xcode project that's set up correctly, run `build-script-helper.py`, passing the path to the downloaded toolchain via the `--toolchain` option, the tool's package name in the `--package-dir` option, and the `generate-xcodeproj` action:


### PR DESCRIPTION
Few issues fixed in these commits:

1. Running build-script-helper.py with an invalid toolchain results in an unhandled OSError (no such file or directory). Refactored the try/excepts into a wrapper that handles the existing error + OSError.

2. Added documentation about including `/usr` in $TOOLCHAIN_DIR. The swift build script was changed to pass the toolchain *including* `/usr` a while back (apple/swift#30565).

3. Fixed the xcode project generation - `SWIFT_STRESS_TESTER_SOURCEKIT_SEARCHPATH` wasn't set when generating the project, which would result in a whole bunch of flags missing a directory. In some cases that just causes a warning but in others it causes the compile to fail completely.