### PR TITLE
Leave -Xfrontend in sourcekit compiler arguments

### DIFF
--- a/SourceKitStressTester/Sources/SwiftSourceKit/SourcekitdRequest.swift
+++ b/SourceKitStressTester/Sources/SwiftSourceKit/SourcekitdRequest.swift
@@ -138,16 +138,9 @@ public struct SourceKitdRequest: CustomStringConvertible {
   public func addCompilerArgsToRequest(_ compilerArguments: [String]?,
                                        _ bufferName: String? = nil) {
     let args = self.addArrayParameter(SourceKitdUID.key_CompilerArgs)
-
     if let compilerArguments = compilerArguments {
       for argument in compilerArguments {
-        switch argument {
-        // Exclude some arguments which SourceKit doesn't want or need.
-        case "-Xfrontend":
-          break
-        default:
-          args.add(argument)
-        }
+        args.add(argument)
       }
     }
   }


### PR DESCRIPTION
Various requests fail due to the removal of only -Xfrontend and not the
next argument as well. This shouldn't be needed any more, so just remove
this logic entirely.