### PR TITLE
Refactor CLI to use ArgumentParser

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -37,12 +37,11 @@ let package = Package(
                                      "-Xlinker", "-F", "-Xlinker", sourcekitSearchPath])]
     ),
     .target(
-      name: "Common",
-      dependencies: ["SwiftToolsSupport-auto"]
+      name: "Common"
     ),
     .target(
       name: "StressTester",
-      dependencies: ["Common", "SwiftToolsSupport-auto", "SwiftSyntax", "SwiftSourceKit"],
+      dependencies: ["Common", "ArgumentParser", "SwiftSyntax", "SwiftSourceKit"],
       swiftSettings: [.unsafeFlags(["-Fsystem", sourcekitSearchPath])],
       linkerSettings: [.unsafeFlags(["-Xlinker", "-F", "-Xlinker", sourcekitSearchPath])]
     ),
@@ -66,17 +65,11 @@ let package = Package(
       name: "StressTesterToolTests",
       dependencies: ["StressTester"],
       swiftSettings: [.unsafeFlags(["-Fsystem", sourcekitSearchPath])],
-      // SwiftPM does not get the rpath for XCTests in multiroot packages right (rdar://56793593)
-      // Add the correct rpath here
-      linkerSettings: [.unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "@loader_path/../../../",
-                                     "-Xlinker", "-F", "-Xlinker", sourcekitSearchPath])]
+      linkerSettings: [.unsafeFlags(["-Xlinker", "-F", "-Xlinker", sourcekitSearchPath])]
     ),
     .testTarget(
       name: "SwiftCWrapperToolTests",
-      dependencies: ["SwiftCWrapper"],
-      // SwiftPM does not get the rpath for XCTests in multiroot packages right (rdar://56793593)
-      // Add the correct rpath here
-      linkerSettings: [.unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "@loader_path/../../../"])]
+      dependencies: ["SwiftCWrapper"]
     )
   ]
 )
@@ -85,11 +78,13 @@ if getenv("SWIFTCI_USE_LOCAL_DEPS") == nil {
   // Building standalone.
   package.dependencies += [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .branch("main")),
     .package(url: "https://github.com/apple/swift-syntax.git", .branch("main")),
   ]
 } else {
   package.dependencies += [
     .package(path: "../../swiftpm/swift-tools-support-core"),
+    .package(path: "../../swift-argument-parser"),
     .package(path: "../../swift-syntax"),
   ]
 }

--- a/SourceKitStressTester/Sources/Common/Message.swift
+++ b/SourceKitStressTester/Sources/Common/Message.swift
@@ -11,18 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import TSCBasic
 
 public protocol Message: Codable, CustomStringConvertible {}
 
 public extension Message {
-  func write(to stream: FileOutputByteStream) throws {
-    let data: Data = try JSONEncoder().encode(self)
-    // messages are separated by newlines
-    stream <<< data <<< "\n"
-    stream.flush()
-  }
-
   init?(from data: Data) {
     guard let message = try? JSONDecoder().decode(Self.self, from: data) else { return nil }
     self = message
@@ -112,7 +104,7 @@ public enum RewriteMode: String, Codable, CaseIterable {
   case insideOut
 }
 
-public struct Page: Codable {
+public struct Page: Codable, Equatable {
   public let number: Int
   public let count: Int
   public var isFirst: Bool {
@@ -122,10 +114,19 @@ public struct Page: Codable {
     return number - 1
   }
 
-  public init(_ number: Int, of count: Int) {
+  public init(_ number: Int = 1, of count: Int = 1) {
     assert(number >= 1 && number <= count)
     self.number = number
     self.count = count
+  }
+}
+
+extension Page: CustomStringConvertible {
+  public var description: String {
+    if number == 1 && count == 1 {
+      return "none"
+    }
+    return "\(number) of \(count)"
   }
 }
 

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -317,7 +317,7 @@ struct SourceKitDocument {
       if responseText.count > maxSize {
         responseText = responseText.prefix(maxSize) + "[truncated]"
       }
-      throw SourceKitError.failed(.missingExpectedResult, request: info, response: responseText.spm_chomp())
+      throw SourceKitError.failed(.missingExpectedResult, request: info, response: responseText.trimmingCharacters(in: .newlines))
     }
   }
 
@@ -356,13 +356,14 @@ struct SourceKitDocument {
   }
 
   private func throwIfInvalid(_ response: SourceKitdResponse, request: RequestInfo) throws {
-    if response.isConnectionInterruptionError || response.isCompilerCrash {
-      throw SourceKitError.crashed(request: request)
-    }
     // FIXME: We don't supply a valid new name for initializer calls for local
     // rename requests. Ignore these errors for now.
     if response.isError, !response.description.contains("does not match the arity of the old name") {
-      throw SourceKitError.failed(.errorResponse, request: request, response: response.description.spm_chomp())
+      throw SourceKitError.failed(.errorResponse, request: request, response: response.description.trimmingCharacters(in: .newlines))
+    }
+
+    if response.isConnectionInterruptionError || response.isCompilerCrash {
+      throw SourceKitError.crashed(request: request)
     }
   }
 

--- a/SourceKitStressTester/Sources/StressTester/StressTester.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTester.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -181,14 +181,24 @@ private extension SourceKitdUID {
 }
 
 public struct StressTesterOptions {
-  public init() {}
+  public var requests: RequestSet
+  public var rewriteMode: RewriteMode
+  public var conformingMethodsTypeList: [String]
+  public var page: Page
+  public var astBuildLimit: Int?
+  public var responseHandler: ((SourceKitResponseData) throws -> Void)?
 
-  public var astBuildLimit: Int? = nil
-  public var requests: RequestSet = .all
-  public var rewriteMode: RewriteMode = .none
-  public var conformingMethodsTypeList = ["s:SQ", "s:SH"] // Equatable and Hashable
-  public var responseHandler: ((SourceKitResponseData) throws -> Void)? = nil
-  public var page = Page(1, of: 1)
+  public init(requests: RequestSet, rewriteMode: RewriteMode,
+              conformingMethodsTypeList: [String], page: Page,
+              astBuildLimit: Int? = nil,
+              responseHandler: ((SourceKitResponseData) throws -> Void)? = nil) {
+    self.requests = requests
+    self.rewriteMode = rewriteMode
+    self.conformingMethodsTypeList = conformingMethodsTypeList
+    self.page = page
+    self.astBuildLimit = astBuildLimit
+    self.responseHandler = responseHandler
+  }
 }
 
 public struct RequestSet: OptionSet {
@@ -233,4 +243,13 @@ public struct RequestSet: OptionSet {
   public static let format = RequestSet(rawValue: 1 << 6)
 
   public static let all: RequestSet = [.cursorInfo, .rangeInfo, .codeComplete, .typeContextInfo, .conformingMethodList, .collectExpressionType, .format]
+}
+
+extension RequestSet: CustomStringConvertible {
+  public var description: String {
+    if self == .all {
+      return "\"All\""
+    }
+    return String(describing: valueNames)
+  }
 }

--- a/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,163 +10,146 @@
 //
 //===----------------------------------------------------------------------===//
 
+import ArgumentParser
 import Foundation
 import Common
-import TSCUtility
-import TSCBasic
 import SwiftSyntax
 
-public struct StressTesterTool {
-  let parser: ArgumentParser
-  let arguments: [String]
+public struct StressTesterTool: ParsableCommand {
+  public static var configuration = CommandConfiguration(
+    abstract: "A utility for finding sourcekitd crashes in a Swift source file"
+  )
 
-  let usage = "<options> <source-file> swiftc <swiftc-args>"
-  let overview = "A utility for finding sourcekitd crashes in a Swift source file"
+  @Option(name: [.long, .customShort("m")], help: """
+    One of 'none' (default), 'basic', 'concurrent', 'insideOut', or 'typoed'
+    """)
+  public var rewriteMode: RewriteMode = .none
 
-  /// Arguments
-  let mode: OptionArgument<RewriteMode>
-  let format: OptionArgument<OutputFormat>
-  let limit: OptionArgument<Int>
-  let page: OptionArgument<Page>
-  let request: OptionArgument<[RequestSet]>
-  let dryRun: OptionArgument<Bool>
-  let reportResponses: OptionArgument<Bool>
-  let conformingMethodsTypeList: OptionArgument<[String]>
-  let file: PositionalArgument<PathArgument>
-  let compilerArgs: PositionalArgument<[String]>
+  @Option(name: .shortAndLong, help: """
+    Format of results. Either 'json' or 'humanReadable'
+    """)
+  public var format: OutputFormat = .humanReadable
 
-  public init(arguments: [String]) {
-    self.arguments = Array(arguments.dropFirst())
+  @Option(name: .shortAndLong, help: ArgumentHelp("""
+    The maximum number of AST builds (triggered by CodeComplete, \
+    TypeContextInfo, ConformingMethodList and file modifications) to \
+    allow per file
+    """, valueName: "n"))
+  public var limit: Int?
 
-    self.parser = ArgumentParser(usage: usage, overview: overview)
-    mode = parser.add(
-      option: "--rewrite-mode", shortName: "-m", kind: RewriteMode.self,
-      usage: "<MODE> One of 'none' (default), 'basic', 'concurrent', 'insideOut', or 'typoed'")
-    format = parser.add(
-      option: "--format", shortName: "-f", kind: OutputFormat.self,
-      usage: "<FORMAT> One of 'json' or 'humanReadable'")
-    limit = parser.add(
-      option: "--limit", shortName: "-l", kind: Int.self,
-      usage: "<N> The maximum number of AST builds (triggered by CodeComplete, TypeContextInfo, ConformingMethodList and file modifications) to allow per file")
-    page = parser.add(
-      option: "--page", shortName: "-p", kind: Page.self,
-      usage: "<PAGE>/<TOTAL> Divides the work for each file into <TOTAL> equal parts" +
-      " and only performs the <PAGE>th group.")
-    request = parser.add(
-      option: "--request", shortName: "-r", kind: [RequestSet].self, strategy: .oneByOne,
-      usage: "<REQUEST> One of '\(RequestSet.all.valueNames.joined(separator: "', '"))', or 'All'")
-    dryRun = parser.add(
-      option: "--dryrun", shortName: "-d", kind: Bool.self,
-      usage: "Dump the sourcekitd requests the stress tester would perform instead of performing them")
-    reportResponses = parser.add(
-      option: "--report-responses", kind: Bool.self,
-      usage: "Output sourcekitd's response to each request the stress tester makes")
-    conformingMethodsTypeList = parser.add(
-      option: "--type-list-item", shortName: "-t", kind: [String].self, strategy: .oneByOne,
-      usage: "The USR of a conformed-to protocol to use for the ConformingMethodList request")
-    file = parser.add(
-      positional: "<source-file>", kind: PathArgument.self, optional: false,
-      usage: "A Swift source file to stress test", completion: .filename)
+  @Option(name: .shortAndLong, help: ArgumentHelp("""
+    Divides the work for each file into <total> equal parts \
+    and only performs the <page>th group.
+    """, valueName: "page/total"))
+  public var page: Page = Page()
 
-    // Note: the required 'swiftc' is to workaround ArgumentParser treating a
-    // compiler option in the first position as something it should parse as an
-    // option. There is no support for '--' to separate positionals at present.
-    compilerArgs = parser.add(
-      positional: "swiftc <compiler-args>", kind: [String].self, strategy: .remaining,
-      usage: "swift compiler arguments for the provided file")
+  @Option(name: .shortAndLong, help: """
+    One of '\(RequestSet.all.valueNames.joined(separator: "\", \""))', \"IDE\",
+    or \"All\"
+    """)
+  public var request: [RequestSet] = [.all]
 
+  @Flag(name: .shortAndLong, help: """
+    Dump the sourcekitd requests the stress tester would perform instead of \
+    performing them
+    """)
+  public var dryRun: Bool = false
+
+  @Flag(name: .long, help: """
+    Output sourcekitd's response to each request the stress tester makes
+    """)
+  public var reportResponses: Bool = false
+
+  @Option(name: [.customLong("type-list-item"), .customShort("t")], help: """
+    The USR of a conformed-to protocol to use for the ConformingMethodList \
+    request
+    """)
+  public var conformingMethodsTypeList: [String] = ["s:SQ", "s:SH"] // Equatable and Hashable
+
+  @Argument(help: "A Swift source file to stress test", completion: .file(),
+            transform: URL.init(fileURLWithPath:))
+  public var file: URL
+
+  @Argument(help: "Swift compiler arguments for the provided file")
+  public var compilerArgs: [String]
+
+  public init() {}
+
+  public mutating func validate() throws {
+    guard FileManager.default.fileExists(atPath: file.path) else {
+      throw ValidationError("File does not exist at \(file.path)")
+    }
   }
 
-  public func run() throws -> Bool {
-    let results = try parse()
-    return try process(results)
-  }
-
-  public func parse() throws -> ArgumentParser.Result {
-    let result = try parser.parse(arguments)
-
-    // validate arguments
-    guard let args = result.get(compilerArgs), let first = args.first, first == "swiftc" else {
-      throw ArgumentParserError.invalidValue(argument: "swiftc <compiler-args>",
-                                             error: ArgumentConversionError.custom("missing 'swiftc' keyword"))
-    }
-    guard args.count > 1 else {
-      throw ArgumentParserError.expectedArguments(parser, ["swiftc <compiler-args>"])
-    }
-
-    return result
-  }
-
-  private func process(_ arguments: ArgumentParser.Result) throws -> Bool {
-    var options = StressTesterOptions()
-    if let mode = arguments.get(mode) {
-      options.rewriteMode = mode
-    }
-    if let limit = arguments.get(limit) {
-      options.astBuildLimit = limit
-    }
-    if let page = arguments.get(page) {
-      options.page = page
-    }
-    if let requests = arguments.get(request) {
-      options.requests = requests.reduce([]) { result, next in result.union(next) }
-    }
-    if let typeList = arguments.get(conformingMethodsTypeList) {
-      options.conformingMethodsTypeList = typeList
-    }
-
-    let format = arguments.get(self.format) ?? .humanReadable
-    let dryRun = arguments.get(self.dryRun) ?? false
-
-    if let reportResponses = arguments.get(self.reportResponses), reportResponses {
-      options.responseHandler = { responseData in
-        try self.report(StressTesterMessage.produced(responseData), as: format)
-      }
-    }
-
-    let absoluteFile = URL(fileURLWithPath: arguments.get(file)!.path.pathString)
-    let args = Array(arguments.get(compilerArgs)!.dropFirst())
+  public func run() throws {
+    let options = StressTesterOptions(
+      requests: request.reduce([]) { result, next in
+        result.union(next)
+      },
+      rewriteMode: rewriteMode,
+      conformingMethodsTypeList: conformingMethodsTypeList,
+      page: page,
+      astBuildLimit: limit,
+      responseHandler: !reportResponses ? nil :
+        { [format] responseData in
+          try StressTesterTool.report(
+            StressTesterMessage.produced(responseData),
+            as: format)
+        })
 
     do {
-      let tester = StressTester(for: absoluteFile, compilerArgs: args, options: options)
+      let tester = StressTester(for: file, compilerArgs: compilerArgs,
+                                options: options)
       if dryRun {
-        let tree = try! SyntaxParser.parse(absoluteFile)
-        try report(tester.computeStartStateAndActions(from: tree).actions, as: format)
+        let tree = try SyntaxParser.parse(file)
+        try StressTesterTool.report(
+          tester.computeStartStateAndActions(from: tree).actions,
+          as: format)
       } else {
         try tester.run()
       }
     } catch let error as SourceKitError {
       let message = StressTesterMessage.detected(error)
-      try report(message, as: format)
-      return false
+      try StressTesterTool.report(message, as: format)
+      throw ExitCode.failure
     }
-    return true
   }
 
-  private func report<T>(_ message: T, as format: OutputFormat) throws where T: Codable & CustomStringConvertible {
+  private static func report<T>(_ message: T, as format: OutputFormat) throws
+  where T: Codable & CustomStringConvertible {
     switch format {
     case .humanReadable:
-      stdoutStream <<< String(describing: message) <<< "\n"
+      print(String(describing: message))
     case .json:
       let data = try JSONEncoder().encode(message)
-      stdoutStream.write(data)
-      stdoutStream.write("\n".data(using: .ascii)!)
+      print(String(data: data, encoding: .utf8)!)
     }
-    stdoutStream.flush()
   }
 }
 
-enum OutputFormat: String {
+public enum OutputFormat: String, ExpressibleByArgument {
   case humanReadable
   case json
 }
 
-extension RequestSet: ArgumentKind {
-  public static var completion: ShellCompletion {
-    return .none
+extension Page: ExpressibleByArgument {
+  public init?(argument: String) {
+    let parts = argument.split(separator: "/", maxSplits: 1,
+                               omittingEmptySubsequences: false)
+    if parts.count == 2 {
+      if let number = Int(parts[0]),
+         let count = Int(parts[1]), number > 0,
+         number <= count {
+        self.init(number, of: count)
+        return
+      }
+    }
+    return nil
   }
+}
 
-  public init(argument: String) throws {
+extension RequestSet: ExpressibleByArgument {
+  public init?(argument: String) {
     switch argument.lowercased() {
     case "format":
       self = .format
@@ -185,46 +168,9 @@ extension RequestSet: ArgumentKind {
     case "all":
       self = .all
     default:
-      throw ArgumentConversionError.unknown(value: argument)
+      return nil
     }
   }
 }
 
-extension OutputFormat: ArgumentKind {
-  static var completion: ShellCompletion {
-    return .none
-  }
-
-  init(argument: String) throws {
-    guard let format = OutputFormat(rawValue: argument) else {
-      throw ArgumentConversionError.unknown(value: argument)
-    }
-    self = format
-  }
-}
-
-extension Page: ArgumentKind {
-  public static var completion: ShellCompletion = .none
-
-  public init(argument: String) throws {
-    let parts = argument.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
-    if parts.count == 2 {
-      if let number = Int(parts[0]), let count = Int(parts[1]), number > 0, number <= count {
-        self.init(number, of: count)
-        return
-      }
-    }
-    throw ArgumentConversionError.unknown(value: argument)
-  }
-}
-
-extension RewriteMode: ArgumentKind {
-  public static var completion: ShellCompletion = .none
-
-  public init(argument: String) throws {
-    guard let mode = RewriteMode(rawValue: argument) else {
-      throw ArgumentConversionError.unknown(value: argument)
-    }
-    self = mode
-  }
-}
+extension RewriteMode: ExpressibleByArgument {}

--- a/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
@@ -80,7 +80,7 @@ final class StressTestOperation: Operation {
     self.file = file
     self.mode = rewriteMode
     self.part = part
-    self.process = ProcessRunner(launchPath: executable, arguments: stressTesterArgs + [file, "swiftc"] + compilerArgs)
+    self.process = ProcessRunner(launchPath: executable, arguments: stressTesterArgs + [file, "--"] + compilerArgs)
   }
 
   var summary: String {

--- a/SourceKitStressTester/Sources/sk-stress-test/main.swift
+++ b/SourceKitStressTester/Sources/sk-stress-test/main.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,19 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import StressTester
-import TSCBasic
 
-let stressTester = StressTesterTool(arguments: CommandLine.arguments)
-
-do {
-  guard try stressTester.run() else {
-    exit(EXIT_FAILURE)
-  }
-} catch {
-  let prefix = CommandLine.arguments.first!
-  stderrStream <<< "\(prefix): \(error)\n"
-  stderrStream.flush()
-  exit(EXIT_FAILURE)
-}
+StressTesterTool.main()

--- a/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
+++ b/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
@@ -141,9 +141,9 @@ class SwiftCWrapperToolTests: XCTestCase {
 
     let defaultInvocations = try! String(contentsOf: URL(fileURLWithPath: testInvocationPath)).split(separator: "\n")
     let defaultExpected = [
-      "--format json --page 1/1 --rewrite-mode none --request Format --request CursorInfo --request RangeInfo --request CodeComplete --request CollectExpressionType \(testFilePath!) swiftc \(testFilePath!)",
-      "--format json --page 1/1 --rewrite-mode concurrent --request Format --request CursorInfo --request RangeInfo --request CodeComplete --request CollectExpressionType \(testFilePath!) swiftc \(testFilePath!)",
-      "--format json --page 1/1 --rewrite-mode insideOut --request Format --request CursorInfo --request RangeInfo --request CodeComplete --request CollectExpressionType \(testFilePath!) swiftc \(testFilePath!)"
+      "--format json --page 1/1 --rewrite-mode none --request Format --request CursorInfo --request RangeInfo --request CodeComplete --request CollectExpressionType \(testFilePath!) -- \(testFilePath!)",
+      "--format json --page 1/1 --rewrite-mode concurrent --request Format --request CursorInfo --request RangeInfo --request CodeComplete --request CollectExpressionType \(testFilePath!) -- \(testFilePath!)",
+      "--format json --page 1/1 --rewrite-mode insideOut --request Format --request CursorInfo --request RangeInfo --request CodeComplete --request CollectExpressionType \(testFilePath!) -- \(testFilePath!)"
     ]
 
     XCTAssertEqual(defaultExpected.count, defaultInvocations.count)
@@ -162,8 +162,8 @@ class SwiftCWrapperToolTests: XCTestCase {
 
     let customInvocations = try! String(contentsOf: URL(fileURLWithPath: testInvocationPath)).split(separator: "\n")
     let customExpected = [
-      "--format json --page 1/1 --rewrite-mode basic --request CursorInfo --request RangeInfo --request CodeComplete --request TypeContextInfo --request ConformingMethodList --request CollectExpressionType --request All --type-list-item s:SomeUSR --type-list-item s:OtherUSR --type-list-item s:ThirdUSR \(testFilePath!) swiftc \(testFilePath!)",
-      "--format json --page 1/1 --rewrite-mode insideOut --request CursorInfo --request RangeInfo --request CodeComplete --request TypeContextInfo --request ConformingMethodList --request CollectExpressionType --request All --type-list-item s:SomeUSR --type-list-item s:OtherUSR --type-list-item s:ThirdUSR \(testFilePath!) swiftc \(testFilePath!)"
+      "--format json --page 1/1 --rewrite-mode basic --request CursorInfo --request RangeInfo --request CodeComplete --request TypeContextInfo --request ConformingMethodList --request CollectExpressionType --request All --type-list-item s:SomeUSR --type-list-item s:OtherUSR --type-list-item s:ThirdUSR \(testFilePath!) -- \(testFilePath!)",
+      "--format json --page 1/1 --rewrite-mode insideOut --request CursorInfo --request RangeInfo --request CodeComplete --request TypeContextInfo --request ConformingMethodList --request CollectExpressionType --request All --type-list-item s:SomeUSR --type-list-item s:OtherUSR --type-list-item s:ThirdUSR \(testFilePath!) -- \(testFilePath!)"
     ]
     XCTAssertEqual(customExpected.count, customInvocations.count)
     for invocation in customInvocations {
@@ -201,10 +201,10 @@ class SwiftCWrapperToolTests: XCTestCase {
     let issue4 = StressTesterIssue.failed(error4)
 
     let issue5 = StressTesterIssue.errored(status: 2, file: "/bob/foo/bar.swift",
-                                          arguments: "--rewrite-mode concurrent /bob/foo/bar.swift swiftc /bob/foo/bar.swift")
+                                          arguments: "--rewrite-mode concurrent /bob/foo/bar.swift -- /bob/foo/bar.swift")
     let issue6 = StressTesterIssue.errored(status: 2,
                                             file: "/bob/foo/bar.swift",
-                                            arguments: "--rewrite-mode basic /bob/foo/bar.swift swiftc /bob/foo/bar.swift")
+                                            arguments: "--rewrite-mode basic /bob/foo/bar.swift -- /bob/foo/bar.swift")
 
     XCTAssertTrue(xfail.matches(issue1))
     XCTAssertFalse(xfail.matches(issue2))


### PR DESCRIPTION
Use the Swift ArgumentParser library rather than parsing available in
SwiftToolsSupport. Remove the dependency on SwiftToolsSupport where not
needed any more (still needed in SwiftCWrapper for the progress bar).

Remove old rpath workaround as that bug is now fixed.