### PR TITLE
Refactor compiler argument handling into separate classes

### DIFF
--- a/SourceKitStressTester/Sources/Common/CompilerArgs.swift
+++ b/SourceKitStressTester/Sources/Common/CompilerArgs.swift
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public struct CompilerArg: Equatable {
+  /// The original argument as passed
+  public let original: String
+
+  /// If the argument is a file list (@/some/file), this is the arguments
+  /// parsed from that file. Otherwise it is an array of a single value - the
+  /// original argument.
+  public let transformed: [String]
+
+  public init(_ argument: String) {
+    self.original = argument
+    self.transformed = fileListArgs(arg: argument) ?? [argument]
+  }
+}
+
+public struct CompilerArgs {
+  /// Main file intended to be compiled
+  public let forFile: URL
+
+  /// Original arguments as passed
+  public let original: [String]
+
+  /// Arguments with any file list arguments (@file) replaced with the
+  /// arguments found in those files
+  public let sourcekitdArgs: [String]
+
+  /// Original arguments but with references to fileToCompile removed. This
+  /// includes replacing any file list with a new file when they contain the
+  /// fileToCompile
+  public let processArgs: [String]
+
+  public init(for file: URL, args: [CompilerArg], tempDir: URL) {
+    self.forFile = file
+    self.original = args.map { $0.original }
+    self.sourcekitdArgs = args.flatMap { $0.transformed }
+    self.processArgs = args.filter { $0.original != file.path }
+      .map { arg in
+        if let listArgs = fileListArgs(arg: arg.original) {
+          let fileRemoved = listArgs.filter { $0 == file.path }
+          if fileRemoved.count != listArgs.count {
+            let newFileList = tempDir.appendingPathComponent(UUID().uuidString)
+              .appendingPathExtension(".SwiftFileList")
+            let data = Data(fileRemoved.joined(separator: "\n").utf8)
+            try! data.write(to: newFileList)
+            return newFileList.path
+          }
+        }
+        return arg.original
+      }
+  }
+}
+
+func fileListArgs(arg: String) -> [String]? {
+  guard arg.starts(with: "@") else {
+    return nil
+  }
+
+  let url = URL(fileURLWithPath: String(arg.dropFirst()) , isDirectory: false)
+  if let content = try? String(contentsOf: url, encoding: .utf8) {
+    return content.split(separator: "\n").map {
+      $0.replacingOccurrences(of: "\\ ", with: " ")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+  }
+  return nil
+}

--- a/SourceKitStressTester/Sources/Common/DriverFileList.swift
+++ b/SourceKitStressTester/Sources/Common/DriverFileList.swift
@@ -19,7 +19,10 @@ public struct DriverFileList {
     guard path.starts(with: "@") else { return nil }
     let url = URL(fileURLWithPath: String(path.dropFirst()), isDirectory: false)
     if let content = try? String(contentsOf: url, encoding: .utf8) {
-      paths = content.split(separator: "\n").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      paths = content.split(separator: "\n").map {
+        $0.replacingOccurrences(of: "\\", with: "")
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+      }
     } else {
       return nil
     }

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -136,7 +136,7 @@ public struct SwiftCWrapper {
         fatalError("cancelled operation before failed operation")
       case .unexecuted:
         fatalError("unterminated operation")
-      case .errored(let status, let arguments):
+      case .errored(let status):
         detectedIssue = .errored(status: status, file: operation.file, arguments: arguments.joined(separator: " "))
       case .failed(let sourceKitError):
         detectedIssue = .failed(sourceKitError)

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapperTool.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapperTool.swift
@@ -53,7 +53,7 @@ public struct SwiftCWrapperTool {
     /// failures json file to mark an unexpected failure as expected.
     let activeConfigEnv = EnvOption("SK_STRESS_ACTIVE_CONFIG", type: String.self)
 
-    guard let swiftc = (try swiftcEnv.get(from: environment) ?? getDefaultSwiftCPath()) else {
+    guard let swiftc = (try swiftcEnv.get(from: environment) ?? pathFromXcrun(for: "swiftc")) else {
       throw EnvOptionError.noFallback(key: swiftcEnv.key, target: "swiftc")
     }
     guard let stressTester = (try stressTesterEnv.get(from: environment) ?? defaultStressTesterPath) else {
@@ -103,18 +103,6 @@ public struct SwiftCWrapperTool {
 
     guard FileManager.default.isExecutableFile(atPath: wrapperPath) else { return nil }
     return wrapperPath
-  }
-
-  func getDefaultSwiftCPath(for toolchain: String? = nil) -> String? {
-    var args = ["-f", "swiftc"]
-    if let toolchain = toolchain {
-      args += ["--toolchain", toolchain]
-    }
-    let result = ProcessRunner(launchPath: "/usr/bin/xcrun", arguments: args).run()
-    guard result.status == EXIT_SUCCESS else { return nil }
-
-    return String(data: result.stdout, encoding: .utf8)?
-      .trimmingCharacters(in: .whitespacesAndNewlines)
   }
 }
 

--- a/SourceKitStressTester/Sources/SwiftSourceKit/SourcekitdRequest.swift
+++ b/SourceKitStressTester/Sources/SwiftSourceKit/SourcekitdRequest.swift
@@ -135,8 +135,7 @@ public struct SourceKitdRequest: CustomStringConvertible {
     return req.dict
   }
 
-  public func addCompilerArgsToRequest(_ compilerArguments: [String]?,
-                                       _ bufferName: String? = nil) {
+  public func addCompilerArgs(_ compilerArguments: [String]?) {
     let args = self.addArrayParameter(SourceKitdUID.key_CompilerArgs)
     if let compilerArguments = compilerArguments {
       for argument in compilerArguments {


### PR DESCRIPTION
Add two new `CompilerArg` and `CompilerArgs` classes that handle:
  1. Mapping file list arguments into separate arguments of all the files
     within (and removing the escaped space, ie. '\ ' if there are any)
  2. Removing the given file from the arguments (and any lists) for use
     in requests that run a separate process and thus need to replace the
     file with the edited one