### PR TITLE
Have ProcessRunner capture stderr as well as stdout

### DIFF
--- a/SourceKitStressTester/Sources/Common/CompilerArgs.swift
+++ b/SourceKitStressTester/Sources/Common/CompilerArgs.swift
@@ -53,7 +53,7 @@ public struct CompilerArgs {
           let fileRemoved = listArgs.filter { $0 == file.path }
           if fileRemoved.count != listArgs.count {
             let newFileList = tempDir.appendingPathComponent(UUID().uuidString)
-              .appendingPathExtension(".SwiftFileList")
+              .appendingPathExtension("SwiftFileList")
             let data = Data(fileRemoved.joined(separator: "\n").utf8)
             try! data.write(to: newFileList)
             return newFileList.path

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -71,7 +71,8 @@ public struct SwiftCWrapper {
 
   func run() throws -> Int32 {
     // Execute the compiler
-    let swiftcResult = ProcessRunner(launchPath: swiftcPath, arguments: arguments).run(capturingOutput: false)
+    let swiftcResult = ProcessRunner(launchPath: swiftcPath, arguments: arguments)
+      .run(captureStdout: false, captureStderr: false)
     guard swiftcResult.status == EXIT_SUCCESS else { return swiftcResult.status }
 
     let startTime = Date()


### PR DESCRIPTION
ProcessRunner did capture stderr at one point but it was reverted to
stdout only as there were various issues with the process hanging and
missing output.

Missing output could have been due to the `terminationHandler` running
before the read handlers were called (which appears to be possible).
Changed the clearing of `readabilityHandler` to be when EOF is reached
instead.

Also using `readData` rather than `availableData` as various online
comments have mentioned `availableData` causing various issues.