### PR TITLE
Add request to test emitting modules with new allow errors flag

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -61,15 +61,18 @@ let package = Package(
       dependencies: ["SwiftCWrapper"]
     ),
 
+    .target(
+      name: "TestHelpers"
+    ),
     .testTarget(
       name: "StressTesterToolTests",
-      dependencies: ["StressTester"],
+      dependencies: ["StressTester", "TestHelpers"],
       swiftSettings: [.unsafeFlags(["-Fsystem", sourcekitSearchPath])],
       linkerSettings: [.unsafeFlags(["-Xlinker", "-F", "-Xlinker", sourcekitSearchPath])]
     ),
     .testTarget(
       name: "SwiftCWrapperToolTests",
-      dependencies: ["SwiftCWrapper"]
+      dependencies: ["SwiftCWrapper", "TestHelpers"]
     )
   ]
 )

--- a/SourceKitStressTester/Sources/Common/ProcessRunner.swift
+++ b/SourceKitStressTester/Sources/Common/ProcessRunner.swift
@@ -27,9 +27,22 @@ public class ProcessRunner {
     process.environment = environment.merging(ProcessInfo.processInfo.environment) { (current, _) in current }
   }
 
-  public func run(captureStdout: Bool = true,
+  public func run(input: String? = nil,
+                  captureStdout: Bool = true,
                   captureStderr: Bool = true) -> ProcessResult {
     let group = DispatchGroup()
+
+    if let input = input {
+      guard let data = input.data(using: .utf8) else {
+        return ProcessResult(status: 1,
+                             stdout: Data(),
+                             stderr: "Invalid input".data(using: .utf8)!)
+      }
+      let inPipe = Pipe()
+      inPipe.fileHandleForWriting.write(data)
+      inPipe.fileHandleForWriting.closeFile()
+      process.standardInput = inPipe
+    }
 
     var outData = Data()
     if captureStdout {

--- a/SourceKitStressTester/Sources/StressTester/Action.swift
+++ b/SourceKitStressTester/Sources/StressTester/Action.swift
@@ -22,13 +22,14 @@ public enum Action: Equatable {
   case typeContextInfo(offset: Int)
   case conformingMethodList(offset: Int)
   case collectExpressionType
+  case testModule
 }
 
 extension Action: CustomStringConvertible {
   public var description: String {
     switch self {
     case .cursorInfo(let offset):
-      return "CusorInfo at offset \(offset)"
+      return "CursorInfo at offset \(offset)"
     case .codeComplete(let offset, let expectedResult):
       return "CodeComplete at offset \(offset) with expectedResult \(expectedResult?.name.name ?? "None")"
     case .rangeInfo(let from, let length):
@@ -43,6 +44,8 @@ extension Action: CustomStringConvertible {
       return "ConformingMethodList at offset \(offset)"
     case .collectExpressionType:
       return "CollectExpressionType"
+    case .testModule:
+      return "TestModule"
     }
   }
 }
@@ -53,7 +56,8 @@ extension Action: Codable {
   }
   public enum BaseAction: String, Codable {
     case cursorInfo, codeComplete, rangeInfo, replaceText, format,
-      typeContextInfo, conformingMethodList, collectExpressionType
+      typeContextInfo, conformingMethodList, collectExpressionType,
+      testModule
   }
 
   public init(from decoder: Decoder) throws {
@@ -86,6 +90,8 @@ extension Action: Codable {
       self = .conformingMethodList(offset: offset)
     case .collectExpressionType:
       self = .collectExpressionType
+    case .testModule:
+      self = .testModule
     }
   }
 
@@ -119,6 +125,8 @@ extension Action: Codable {
       try container.encode(offset, forKey: .offset)
     case .collectExpressionType:
       try container.encode(BaseAction.collectExpressionType, forKey: .action)
+    case .testModule:
+      try container.encode(BaseAction.testModule, forKey: .action)
     }
   }
 }

--- a/SourceKitStressTester/Sources/SwiftCWrapper/IssueManager.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/IssueManager.swift
@@ -127,7 +127,8 @@ extension StressTesterIssue: Codable {
     switch try container.decode(BaseMessage.self, forKey: .kind) {
     case .failed:
       let sourceKitError = try container.decode(SourceKitError.self, forKey: .sourceKitError)
-      self = .failed(sourceKitError)
+      let arguments = try container.decode(String.self, forKey: .arguments)
+      self = .failed(sourceKitError: sourceKitError, arguments: arguments)
     case .errored:
       let status = try container.decode(Int32.self, forKey: .status)
       let file = try container.decode(String.self, forKey: .file)
@@ -139,9 +140,10 @@ extension StressTesterIssue: Codable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     switch self {
-    case .failed(let sourceKitError):
+    case .failed(let sourceKitError, let arguments):
       try container.encode(BaseMessage.failed, forKey: .kind)
       try container.encode(sourceKitError, forKey: .sourceKitError)
+      try container.encode(arguments, forKey: .arguments)
     case .errored(let status, let file, let arguments):
       try container.encode(BaseMessage.errored, forKey: .kind)
       try container.encode(status, forKey: .status)

--- a/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
@@ -65,7 +65,8 @@ final class StressTestOperation: Operation {
 
   init(file: String, rewriteMode: RewriteMode, requests: [RequestKind]?,
        conformingMethodTypes: [String]?, limit: Int?, part: (Int, of: Int),
-       reportResponses: Bool, compilerArgs: [String], executable: String) {
+       reportResponses: Bool, compilerArgs: [String], executable: String,
+       swiftc: String) {
     var stressTesterArgs = ["--format", "json", "--page", "\(part.0)/\(part.of)", "--rewrite-mode", rewriteMode.rawValue]
     if let limit = limit {
       stressTesterArgs += ["--limit", String(limit)]
@@ -79,6 +80,7 @@ final class StressTestOperation: Operation {
     if reportResponses {
       stressTesterArgs += ["--report-responses"]
     }
+    stressTesterArgs += ["--swiftc", swiftc]
     stressTesterArgs.append(file)
     stressTesterArgs.append("--")
     stressTesterArgs.append(contentsOf: compilerArgs)

--- a/SourceKitStressTester/Sources/TestHelpers/Script.swift
+++ b/SourceKitStressTester/Sources/TestHelpers/Script.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public struct ExecutableScript {
+  public let file: URL
+  let invocationFile: URL?
+
+  @discardableResult
+  public init(at file: URL, exitCode: Int32, stdout: String? = nil,
+              stderr: String? = nil,
+              recordInvocationIn invocationFile: URL? = nil) {
+    self.file = file
+    self.invocationFile = invocationFile
+
+    var lines = ["#!/usr/bin/env bash"]
+    if let stdout = stdout {
+      lines.append("echo '\(stdout)'")
+    }
+    if let stderr = stderr {
+      lines.append("echo '\(stderr)' >&2")
+    }
+    if let invocationFile = invocationFile {
+      lines.append("echo $@ >> \(invocationFile.path)")
+    }
+    lines.append("exit \(exitCode)")
+
+    let content = lines.joined(separator: "\n").data(using: .utf8)
+    FileManager.default.createFile(
+      atPath: file.path, contents: content,
+      attributes: [FileAttributeKey.posixPermissions: 0o0755])
+  }
+
+  public func retrieveInvocations() -> [Substring] {
+    return (try? String(contentsOf: invocationFile!).split(separator: "\n")) ?? []
+  }
+}

--- a/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
@@ -21,14 +21,25 @@ class ActionGeneratorTests: XCTestCase {
   var testFile: URL!
   var testFileContent: String!
 
+  private let ALL_ACTIONS: [Action.BaseAction] = [
+    .format, .codeComplete, .cursorInfo, .rangeInfo, .conformingMethodList,
+    .typeContextInfo, .collectExpressionType, .replaceText, .testModule]
+
   func testRequestActionGenerator() {
     let actions = RequestActionGenerator().generate(for: testFile)
-    verify(actions, rewriteMode: .none, expectedActionTypes: [.format, .codeComplete, .cursorInfo, .rangeInfo, .conformingMethodList, .typeContextInfo, .collectExpressionType])
+    let expectedActions = ALL_ACTIONS.filter({ $0 != .replaceText })
+
+    verify(actions, rewriteMode: .none, expectedActionTypes: expectedActions)
 
     XCTAssertEqual(actions.filter{
       if case .collectExpressionType = $0 { return true }
       return false
     }.count, 1, "there is a single CollectExpressionType action")
+
+    XCTAssertEqual(actions.filter{
+      if case .testModule = $0 { return true }
+      return false
+    }.count, 1, "there is a single TestModule action")
 
     // I=CursorInfo, C=CodeComplete, T=TypeContextInfo, M=ConformingMethodList, R=RangeInfo(start), E=RangeInfo(end)
     XCTAssertEqual(ActionMarkup(actions, in: testFileContent).markedUpSource, """
@@ -153,22 +164,23 @@ class ActionGeneratorTests: XCTestCase {
 
   func testRewriteActionGenerator() {
     let actions = BasicRewriteActionGenerator().generate(for: testFile)
-    verify(actions, rewriteMode: .basic, expectedActionTypes: [.format, .codeComplete, .cursorInfo, .rangeInfo, .conformingMethodList, .typeContextInfo, .collectExpressionType, .replaceText])
+    verify(actions, rewriteMode: .basic, expectedActionTypes: ALL_ACTIONS)
   }
 
   func testTypoRewriteActionGenerator() {
     let actions = TypoActionGenerator().generate(for: testFile)
-    verify(actions, rewriteMode: .typoed, expectedActionTypes: [.format, .codeComplete, .cursorInfo, .conformingMethodList, .typeContextInfo, .replaceText])
+    let expectedActions = ALL_ACTIONS.filter({ $0 != .rangeInfo && $0 != .collectExpressionType})
+    verify(actions, rewriteMode: .typoed, expectedActionTypes: expectedActions)
   }
 
   func testConcurrentRewriteActionGenerator() {
     let actions = ConcurrentRewriteActionGenerator().generate(for: testFile)
-    verify(actions, rewriteMode: .concurrent, expectedActionTypes: [.format, .codeComplete, .cursorInfo, .conformingMethodList, .typeContextInfo, .collectExpressionType, .replaceText, .rangeInfo])
+    verify(actions, rewriteMode: .concurrent, expectedActionTypes: ALL_ACTIONS)
   }
 
   func testInsideOutActionGenerator() {
     let actions = InsideOutRewriteActionGenerator().generate(for: testFile)
-    verify(actions, rewriteMode: .insideOut, expectedActionTypes: [.format, .codeComplete, .cursorInfo, .conformingMethodList, .typeContextInfo, .collectExpressionType, .replaceText, .rangeInfo])
+    verify(actions, rewriteMode: .insideOut, expectedActionTypes: ALL_ACTIONS)
 
     let edits = InsideOutRewriteActionGenerator().generate(for: "a.b([.c])").filter {
         guard case .replaceText = $0 else { return false }
@@ -209,6 +221,8 @@ class ActionGeneratorTests: XCTestCase {
         break
       case .format(let offset):
         XCTAssertTrue(offset >= 0 && offset <= eof)
+      case .testModule:
+        break;
       }
     }
     XCTAssertEqual(state.source, testFileContent)
@@ -231,6 +245,8 @@ class ActionGeneratorTests: XCTestCase {
         return .collectExpressionType
       case .format:
         return .format
+      case .testModule:
+        return .testModule
       }
     })
 
@@ -272,6 +288,11 @@ class ActionGeneratorTests: XCTestCase {
 
     FileManager.default.createFile(atPath: testFile.path, contents: testFileContent.data(using: .utf8))
   }
+
+  override func tearDown() {
+    super.tearDown()
+    try? FileManager.default.removeItem(at: workspace)
+  }
 }
 
 final class ActionMarkup {
@@ -304,6 +325,8 @@ final class ActionMarkup {
           return [] // no associated location
         case .format(let offset):
           return [(offset, "F")]
+        case .testModule:
+          return []
         }
       }
       .enumerated()


### PR DESCRIPTION
A new request "TestModule" emits modules with the new Swift frontend
flag "-experimental-allow-module-with-compiler-errors". It then uses
sourcekitd to generate the interface for the compiled module, checking
that it can be read back in without errors.

The test module action is skipped for tokens within function bodies as
its assumed these will not be parsed/typechecked in the actual use case
anyway.