### PR TITLE
Add output for reproducing with sk-stress-test on failure

### DIFF
--- a/SourceKitStressTester/Sources/Common/CompilerArgs.swift
+++ b/SourceKitStressTester/Sources/Common/CompilerArgs.swift
@@ -101,6 +101,15 @@ public struct CompilerArgs {
   }
 }
 
+public func escapeArgs(_ args: [String]) -> String {
+  return args.map { arg in
+    if arg.contains(" ") {
+      return "\"\(arg)\""
+    }
+    return arg
+  }.joined(separator: " ")
+}
+
 func fileListArgs(arg: String) -> [String]? {
   guard arg.starts(with: "@") else {
     return nil

--- a/SourceKitStressTester/Sources/Common/Message.swift
+++ b/SourceKitStressTester/Sources/Common/Message.swift
@@ -365,27 +365,27 @@ extension RequestInfo: CustomStringConvertible {
     case .editorClose(let document):
       return "EditorClose on \(document)"
     case .cursorInfo(let document, let offset, let args):
-      return "CursorInfo in \(document) at offset \(offset) with args: \(args.joined(separator: " "))"
+      return "CursorInfo in \(document) at offset \(offset) with args: \(escapeArgs(args))"
     case .rangeInfo(let document, let offset, let length, let args):
-      return "RangeInfo in \(document) at offset \(offset) for length \(length) with args: \(args.joined(separator: " "))"
+      return "RangeInfo in \(document) at offset \(offset) for length \(length) with args: \(escapeArgs(args))"
     case .codeComplete(let document, let offset, let args):
-      return "CodeComplete in \(document) at offset \(offset) with args: \(args.joined(separator: " "))"
+      return "CodeComplete in \(document) at offset \(offset) with args: \(escapeArgs(args))"
     case .semanticRefactoring(let document, let offset, let kind, let args):
-      return "SemanticRefactoring (\(kind)) in \(document) at offset \(offset) with args: \(args.joined(separator: " "))"
+      return "SemanticRefactoring (\(kind)) in \(document) at offset \(offset) with args: \(escapeArgs(args))"
     case .editorReplaceText(let document, let offset, let length, let text):
       return "ReplaceText in \(document) at offset \(offset) for length \(length) with text: \(text)"
     case .format(let document, let offset):
       return "Format in \(document) at offset \(offset)"
     case .typeContextInfo(let document, let offset, let args):
-      return "TypeContextInfo in \(document) at offset \(offset) with args: \(args.joined(separator: " "))"
+      return "TypeContextInfo in \(document) at offset \(offset) with args: \(escapeArgs(args))"
     case .conformingMethodList(let document, let offset, let typeList, let args):
-      return "ConformingMethodList in \(document) at offset \(offset) conforming to \(typeList.joined(separator: ", ")) with args: \(args.joined(separator: " "))"
+      return "ConformingMethodList in \(document) at offset \(offset) conforming to \(typeList.joined(separator: ", ")) with args: \(escapeArgs(args))"
     case .collectExpressionType(let document, let args):
-      return "CollectExpressionType in \(document) with args: \(args.joined(separator: " "))"
+      return "CollectExpressionType in \(document) with args: \(escapeArgs(args))"
     case .writeModule(let document, let args):
-      return "WriteModule for \(document) with args: \(args.joined(separator: " "))"
-    case .interfaceGen(let document, let modulePath, let args):
-      return "InterfaceGen for \(document) compiled to \(modulePath) with args: \(args.joined(separator: " "))"
+      return "WriteModule for \(document) with args: \(escapeArgs(args))"
+    case .interfaceGen(let document, let moduleName, let args):
+      return "InterfaceGen for \(document) compiled as \(moduleName) with args: \(escapeArgs(args))"
     }
   }
 }

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -147,10 +147,10 @@ public struct SwiftCWrapper {
         fatalError("unterminated operation")
       case .errored(let status):
         detectedIssue = .errored(status: status, file: operation.file,
-                                 arguments: operation.args.joined(separator: " "))
+                                 arguments: escapeArgs(operation.args))
       case .failed(let sourceKitError):
         detectedIssue = .failed(sourceKitError: sourceKitError,
-                                arguments: operation.args.joined(separator: " "))
+                                arguments: escapeArgs(operation.args))
         fallthrough
       case .passed:
         processedFiles.insert(operation.file)
@@ -274,14 +274,13 @@ public enum StressTesterIssue: CustomStringConvertible {
 
   public var description: String {
     switch self {
-    case .failed(let error, _):
-      return String(describing: error)
-    case .errored(let status, let file, let arguments):
+    case .failed(let sourceKitError, let arguments):
+      return String(describing: sourceKitError) +
+        "\n\nReproduce with:\nsk-stress-test \(arguments)\n"
+    case .errored(let status, _, let arguments):
       return """
-        sk-stress-test errored
-          exit code: \(status)
-          file: \(file)
-          arguments: \(arguments)
+        sk-stress-test errored with exit code \(status). Reproduce with:
+        sk-stress-test \(arguments)\n
         """
     }
   }


### PR DESCRIPTION
Since arguments to swiftc are modified when emitting modules (to remove
the original file and replace with '-'), it's useful to have the full
sk-stress-test commandline in order to reproduce the error.