### PR TITLE
Only report missing expected failures for request types that ran

### DIFF
--- a/SourceKitStressTester/Sources/Common/Message.swift
+++ b/SourceKitStressTester/Sources/Common/Message.swift
@@ -539,3 +539,43 @@ extension StressTesterMessage: CustomStringConvertible {
     }
   }
 }
+
+public enum RequestKind: String, CaseIterable, CustomStringConvertible {
+  case cursorInfo = "CursorInfo"
+  case rangeInfo = "RangeInfo"
+  case codeComplete = "CodeComplete"
+  case typeContextInfo = "TypeContextInfo"
+  case conformingMethodList = "ConformingMethodList"
+  case collectExpressionType = "CollectExpressionType"
+  case format = "Format"
+  case testModule = "TestModule"
+  case ide = "IDE"
+  case all = "All"
+
+  public var description: String { self.rawValue }
+
+  public static let ideRequests: [RequestKind] =
+    [.cursorInfo, .rangeInfo, .codeComplete, .collectExpressionType, .format,
+     .typeContextInfo, .conformingMethodList]
+  public static let allRequests: [RequestKind] = ideRequests +
+    [.testModule]
+
+  public static func byName(_ name: String) -> RequestKind? {
+    let lower = name.lowercased()
+    return RequestKind.allCases
+      .first(where: { $0.rawValue.lowercased() == lower })
+  }
+
+  public static func reduce(_ kinds: [RequestKind]) -> Set<RequestKind> {
+    return Set(kinds.flatMap { kind -> [RequestKind] in
+      switch kind {
+      case .ide:
+        return ideRequests
+      case .all:
+        return allRequests
+      default:
+        return [kind]
+      }
+    })
+  }
+}

--- a/SourceKitStressTester/Sources/StressTester/StressTester.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTester.swift
@@ -184,7 +184,7 @@ private extension SourceKitdUID {
 }
 
 public struct StressTesterOptions {
-  public var requests: RequestSet
+  public var requests: Set<RequestKind>
   public var rewriteMode: RewriteMode
   public var conformingMethodsTypeList: [String]
   public var page: Page
@@ -193,7 +193,7 @@ public struct StressTesterOptions {
   public var responseHandler: ((SourceKitResponseData) throws -> Void)?
   public var dryRun: (([Action]) throws -> Void)?
 
-  public init(requests: RequestSet, rewriteMode: RewriteMode,
+  public init(requests: Set<RequestKind>, rewriteMode: RewriteMode,
               conformingMethodsTypeList: [String], page: Page,
               tempDir: URL, astBuildLimit: Int? = nil,
               responseHandler: ((SourceKitResponseData) throws -> Void)? = nil,
@@ -206,67 +206,5 @@ public struct StressTesterOptions {
     self.astBuildLimit = astBuildLimit
     self.responseHandler = responseHandler
     self.dryRun = dryRun
-  }
-}
-
-public struct RequestSet: OptionSet {
-  public let rawValue: Int
-
-  public init(rawValue: Int) {
-    self.rawValue = rawValue
-  }
-
-  public var valueNames: [String] {
-    var requests = [String]()
-    if contains(.codeComplete) {
-      requests.append("CodeComplete")
-    }
-    if contains(.cursorInfo) {
-      requests.append("CursorInfo")
-    }
-    if contains(.rangeInfo) {
-      requests.append("RangeInfo")
-    }
-    if contains(.typeContextInfo) {
-      requests.append("TypeContextInfo")
-    }
-    if contains(.conformingMethodList) {
-      requests.append("ConformingMethodList")
-    }
-    if contains(.collectExpressionType) {
-      requests.append("CollectExpressionType")
-    }
-    if self.contains(.format) {
-      requests.append("Format")
-    }
-    if self.contains(.testModule) {
-      requests.append("TestModule")
-    }
-    return requests
-  }
-
-  public static let cursorInfo = RequestSet(rawValue: 1 << 0)
-  public static let rangeInfo = RequestSet(rawValue: 1 << 1)
-  public static let codeComplete = RequestSet(rawValue: 1 << 2)
-  public static let typeContextInfo = RequestSet(rawValue: 1 << 3)
-  public static let conformingMethodList = RequestSet(rawValue: 1 << 4)
-  public static let collectExpressionType = RequestSet(rawValue: 1 << 5)
-  public static let format = RequestSet(rawValue: 1 << 6)
-  public static let testModule = RequestSet(rawValue: 1 << 7)
-
-  public static let ide: RequestSet = [.cursorInfo, .rangeInfo, .codeComplete,
-                                       .typeContextInfo, .conformingMethodList,
-                                       .collectExpressionType, .format]
-  public static let all: RequestSet = ide.union(RequestSet([.testModule]))
-}
-
-extension RequestSet: CustomStringConvertible {
-  public var description: String {
-    if self == .ide {
-      return "\"IDE\""
-    } else if self == .all {
-      return "\"All\""
-    }
-    return String(describing: valueNames)
   }
 }

--- a/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
@@ -43,11 +43,9 @@ public struct StressTesterTool: ParsableCommand {
     """, valueName: "page/total"))
   public var page: Page = Page()
 
-  @Option(name: .shortAndLong, help: """
-    One of '\(RequestSet.all.valueNames.joined(separator: "\", \""))', \"IDE\",
-    or \"All\"
-    """)
-  public var request: [RequestSet] = [.ide]
+  @Option(name: [.customLong("request"), .customShort("r")],
+          help: "One of '\(RequestKind.allCases.map({ $0.rawValue }).joined(separator: "\", \""))'")
+  public var requests: [RequestKind] = [.ide]
 
   @Flag(name: .shortAndLong, help: """
     Dump the sourcekitd requests the stress tester would perform instead of \
@@ -124,9 +122,7 @@ public struct StressTesterTool: ParsableCommand {
 
   public func run() throws {
     let options = StressTesterOptions(
-      requests: request.reduce([]) { result, next in
-        result.union(next)
-      },
+      requests: RequestKind.reduce(requests),
       rewriteMode: rewriteMode,
       conformingMethodsTypeList: conformingMethodsTypeList,
       page: page,
@@ -195,32 +191,12 @@ extension Page: ExpressibleByArgument {
   }
 }
 
-extension RequestSet: ExpressibleByArgument {
+extension RequestKind: ExpressibleByArgument {
   public init?(argument: String) {
-    switch argument.lowercased() {
-    case "format":
-      self = .format
-    case "cursorinfo":
-      self = .cursorInfo
-    case "rangeinfo":
-      self = .rangeInfo
-    case "codecomplete":
-      self = .codeComplete
-    case "typecontextinfo":
-      self = .typeContextInfo
-    case "conformingmethodlist":
-      self = .conformingMethodList
-    case "collectexpressiontype":
-      self = .collectExpressionType
-    case "testmodule":
-      self = .testModule
-    case "ide":
-      self = .ide
-    case "all":
-      self = .all
-    default:
+    guard let kind = RequestKind.byName(argument) else {
       return nil
     }
+    self = kind
   }
 }
 

--- a/SourceKitStressTester/Sources/SwiftCWrapper/ExpectedIssue.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/ExpectedIssue.swift
@@ -344,5 +344,38 @@ public extension ExpectedIssue {
       case cursorInfo, codeComplete, rangeInfo, semanticRefactoring, typeContextInfo, conformingMethodList, collectExpressionType, format, writeModule, interfaceGen
       case stressTesterCrash
     }
+
+    func enabledFor(request: RequestKind) -> Bool {
+      switch self {
+      case .editorOpen:
+        return true
+      case .editorClose:
+        return true
+      case .editorReplaceText:
+        return true
+      case .cursorInfo:
+        return request == .cursorInfo
+      case .format:
+        return request == .format
+      case .codeComplete:
+        return request == .codeComplete
+      case .rangeInfo:
+        return request == .rangeInfo
+      case .typeContextInfo:
+        return request == .typeContextInfo
+      case .conformingMethodList:
+        return request == .conformingMethodList
+      case .collectExpressionType:
+        return request == .collectExpressionType
+      case .writeModule:
+        return request == .testModule
+      case .interfaceGen:
+        return request == .testModule
+      case .semanticRefactoring:
+        return request == .cursorInfo || request == .rangeInfo
+      case .stressTesterCrash:
+        return true
+      }
+    }
   }
 }

--- a/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
@@ -63,7 +63,7 @@ final class StressTestOperation: Operation {
   private let mode: RewriteMode
   private let process: ProcessRunner
 
-  init(file: String, rewriteMode: RewriteMode, requests: [RequestKind]?,
+  init(file: String, rewriteMode: RewriteMode, requests: Set<RequestKind>,
        conformingMethodTypes: [String]?, limit: Int?, part: (Int, of: Int),
        reportResponses: Bool, compilerArgs: [String], executable: String,
        swiftc: String) {
@@ -71,9 +71,7 @@ final class StressTestOperation: Operation {
     if let limit = limit {
       stressTesterArgs += ["--limit", String(limit)]
     }
-    if let requests = requests {
-      stressTesterArgs += requests.flatMap { ["--request", $0.rawValue] }
-    }
+    stressTesterArgs += requests.flatMap { ["--request", $0.rawValue] }
     if let types = conformingMethodTypes {
       stressTesterArgs += types.flatMap { ["--type-list-item", $0] }
     }

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -22,7 +22,7 @@ public struct SwiftCWrapper {
   let stressTesterPath: String
   let astBuildLimit: Int?
   let rewriteModes: [RewriteMode]
-  let requestKinds: [RequestKind]
+  let requestKinds: Set<RequestKind>
   let conformingMethodTypes: [String]?
   let ignoreIssues: Bool
   let issueManager: IssueManager?
@@ -31,7 +31,13 @@ public struct SwiftCWrapper {
   let failFast: Bool
   let suppressOutput: Bool
 
-  public init(swiftcArgs: [String], swiftcPath: String, stressTesterPath: String, astBuildLimit: Int?, rewriteModes: [RewriteMode]?, requestKinds: [RequestKind]?, conformingMethodTypes: [String]?, ignoreIssues: Bool, issueManager: IssueManager?, maxJobs: Int?, dumpResponsesPath: String?, failFast: Bool, suppressOutput: Bool) {
+  public init(swiftcArgs: [String], swiftcPath: String,
+              stressTesterPath: String, astBuildLimit: Int?,
+              rewriteModes: [RewriteMode], requestKinds: Set<RequestKind>,
+              conformingMethodTypes: [String]?, ignoreIssues: Bool,
+              issueManager: IssueManager?, maxJobs: Int?,
+              dumpResponsesPath: String?, failFast: Bool,
+              suppressOutput: Bool) {
     self.arguments = swiftcArgs
     self.swiftcPath = swiftcPath
     self.stressTesterPath = stressTesterPath
@@ -40,8 +46,8 @@ public struct SwiftCWrapper {
     self.issueManager = issueManager
     self.failFast = failFast
     self.suppressOutput = suppressOutput
-    self.rewriteModes = rewriteModes ?? [.none, .concurrent, .insideOut]
-    self.requestKinds = requestKinds ?? [.format, .cursorInfo, .rangeInfo, .codeComplete, .collectExpressionType]
+    self.rewriteModes = rewriteModes
+    self.requestKinds = requestKinds
     self.conformingMethodTypes = conformingMethodTypes
     self.maxJobs = maxJobs
     self.dumpResponsesPath = dumpResponsesPath
@@ -242,18 +248,6 @@ private struct OrderingBuffer<T> {
       nextItemIndex += 1
     }
   }
-}
-
-public enum RequestKind: String, CaseIterable {
-  case cursorInfo = "CursorInfo"
-  case rangeInfo = "RangeInfo"
-  case codeComplete = "CodeComplete"
-  case typeContextInfo = "TypeContextInfo"
-  case conformingMethodList = "ConformingMethodList"
-  case collectExpressionType = "CollectExpressionType"
-  case format = "Format"
-  case testModule = "TestModule"
-  case all = "All"
 }
 
 fileprivate extension TimeInterval {

--- a/SourceKitStressTester/Sources/TestHelpers/Script.swift
+++ b/SourceKitStressTester/Sources/TestHelpers/Script.swift
@@ -42,6 +42,8 @@ public struct ExecutableScript {
   }
 
   public func retrieveInvocations() -> [Substring] {
-    return (try? String(contentsOf: invocationFile!).split(separator: "\n")) ?? []
+    let contents = (try? String(contentsOf: invocationFile!).split(separator: "\n")) ?? []
+    try? FileManager.default.removeItem(at: invocationFile!)
+    return contents
   }
 }

--- a/SourceKitStressTester/Tests/StressTesterToolTests/StressTesterToolTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/StressTesterToolTests.swift
@@ -38,7 +38,7 @@ class StressTesterToolTests: XCTestCase {
       XCTAssertEqual(defaults.format, .humanReadable)
       XCTAssertEqual(defaults.limit, nil)
       XCTAssertEqual(defaults.page, Page())
-      XCTAssertEqual(defaults.request, [.ide])
+      XCTAssertEqual(defaults.requests, [.ide])
       XCTAssertEqual(defaults.dryRun, false)
       XCTAssertEqual(defaults.reportResponses, false)
       XCTAssertEqual(defaults.conformingMethodsTypeList, ["s:SQ", "s:SH"])
@@ -79,7 +79,7 @@ class StressTesterToolTests: XCTestCase {
         XCTAssertEqual(tool.format, .json)
         XCTAssertEqual(tool.limit, 1)
         XCTAssertEqual(tool.page, Page(2, of: 5))
-        XCTAssertEqual(tool.request, [.cursorInfo, .codeComplete])
+        XCTAssertEqual(tool.requests, [.cursorInfo, .codeComplete])
         XCTAssertEqual(tool.dryRun, true)
         XCTAssertEqual(tool.reportResponses, true)
         XCTAssertEqual(tool.conformingMethodsTypeList, ["foo", "bar"])
@@ -105,7 +105,7 @@ class StressTesterToolTests: XCTestCase {
 
   func testDumpResponses() {
     var responses = [SourceKitResponseData]()
-    let options = StressTesterOptions(requests: .codeComplete,
+    let options = StressTesterOptions(requests: [.codeComplete],
                                       rewriteMode: .none,
                                       conformingMethodsTypeList: [],
                                       page: Page(),
@@ -140,7 +140,7 @@ class StressTesterToolTests: XCTestCase {
                 "-num-threads", "2",
                 "-output-file-map", "/none/here",
                 testFile.path].map({ CompilerArg($0) })
-    let options = StressTesterOptions(requests: .testModule,
+    let options = StressTesterOptions(requests: [.testModule],
                                       rewriteMode: .none,
                                       conformingMethodsTypeList: [],
                                       page: Page(),


### PR DESCRIPTION
Filter out expected failures for request types that weren't actually run
to reduce confusion when reading through the wrapper output.