### PR TITLE
Use the same argument parser as the main swift repo

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -81,7 +81,7 @@ if getenv("SWIFTCI_USE_LOCAL_DEPS") == nil {
   // Building standalone.
   package.dependencies += [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .branch("main")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.3.0")),
     .package(url: "https://github.com/apple/swift-syntax.git", .branch("main")),
   ]
 } else {

--- a/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
@@ -85,7 +85,7 @@ public struct StressTesterTool: ParsableCommand {
 
   public init() {}
 
-  public mutating func validate() throws {
+  private mutating func customValidate() throws {
     let hasFileCompilerArg = compilerArgs.contains { arg in
       arg.transformed.contains { $0 == file.path }
     }
@@ -122,7 +122,12 @@ public struct StressTesterTool: ParsableCommand {
     }
   }
 
-  public func run() throws {
+  public mutating func run() throws {
+    // FIXME: Remove this and rename `customValidate` to `validate` once swift
+    // is using an argument parser with c17e00a (ie. keeping mutations in
+    // `validate`).
+    try customValidate()
+
     let options = StressTesterOptions(
       requests: request.reduce([]) { result, next in
         result.union(next)

--- a/SourceKitStressTester/Tests/StressTesterToolTests/StressTesterToolTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/StressTesterToolTests.swift
@@ -30,7 +30,8 @@ class StressTesterToolTests: XCTestCase {
     XCTAssertThrowsError(try StressTesterTool.parse([testFile.path]))
 
     // Compiler args missing file
-    XCTAssertThrowsError(try StressTesterTool.parse([testFile.path, "--", "anything"]))
+    // FIXME: Add back in when validate is back to normal
+    // XCTAssertThrowsError(try StressTesterTool.parse([testFile.path, "--", "anything"]))
 
     // Defaults
     StressTesterToolTests.assertParse(valid) { defaults in
@@ -42,7 +43,8 @@ class StressTesterToolTests: XCTestCase {
       XCTAssertEqual(defaults.dryRun, false)
       XCTAssertEqual(defaults.reportResponses, false)
       XCTAssertEqual(defaults.conformingMethodsTypeList, ["s:SQ", "s:SH"])
-      XCTAssertEqual(defaults.swiftc, swiftcPath)
+      // FIXME: Change to swiftcPath when validate is back to normal
+      XCTAssertEqual(defaults.swiftc, nil)
       XCTAssertEqual(defaults.file, testFile)
       XCTAssertEqual(defaults.compilerArgs, [CompilerArg(testFile!.path)])
     }


### PR DESCRIPTION
The main swift repo is using argument parser 0.3.0. This version is
missing c17e00a, which fixes a regression where validate did not store
mutations.

As a temporary fix, downgrade to 0.3.0 in standalone clones and call a
renamed validate function in run manually.

Resolves rdar://71634533

Note:
The main swift repo uses specifically 0.3.0 but swift-driver, sourcekit-lsp, and swift-package-manager all use 0.3.x. Should I change this to upToNextMinor to match those packages or match the swift repo version as it is now?

Both seem somewhat fragile, would be nice if there was a better solution.