### PR TITLE
Add new request limit that randomly distributes requests

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -346,6 +346,7 @@ struct SourceKitDocument {
     return (info, response)
   }
 
+  @discardableResult
   mutating func replaceText(offset: Int, length: Int, text: String) throws -> (SourceFileSyntax, SourceKitdResponse) {
     let request = SourceKitdRequest(uid: .request_EditorReplaceText)
     request.addParameter(.key_Name, value: args.forFile.path)

--- a/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
@@ -64,12 +64,16 @@ final class StressTestOperation: Operation {
   private let process: ProcessRunner
 
   init(file: String, rewriteMode: RewriteMode, requests: Set<RequestKind>,
-       conformingMethodTypes: [String]?, limit: Int?, part: (Int, of: Int),
+       conformingMethodTypes: [String]?, limit: Int?, limitSeed: UInt64?,
+       part: (Int, of: Int),
        reportResponses: Bool, compilerArgs: [String], executable: String,
        swiftc: String) {
     var stressTesterArgs = ["--format", "json", "--page", "\(part.0)/\(part.of)", "--rewrite-mode", rewriteMode.rawValue]
     if let limit = limit {
       stressTesterArgs += ["--limit", String(limit)]
+    }
+    if let limitSeed = limitSeed {
+      stressTesterArgs += ["--limit-seed", String(limitSeed)]
     }
     stressTesterArgs += requests.flatMap { ["--request", $0.rawValue] }
     if let types = conformingMethodTypes {

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -20,7 +20,8 @@ public struct SwiftCWrapper {
   let arguments: [String]
   let swiftcPath: String
   let stressTesterPath: String
-  let astBuildLimit: Int?
+  let requestLimit: Int?
+  let requestLimitSeed: UInt64?
   let rewriteModes: [RewriteMode]
   let requestKinds: Set<RequestKind>
   let conformingMethodTypes: [String]?
@@ -32,7 +33,8 @@ public struct SwiftCWrapper {
   let suppressOutput: Bool
 
   public init(swiftcArgs: [String], swiftcPath: String,
-              stressTesterPath: String, astBuildLimit: Int?,
+              stressTesterPath: String, requestLimit: Int?,
+              requestLimitSeed: UInt64?,
               rewriteModes: [RewriteMode], requestKinds: Set<RequestKind>,
               conformingMethodTypes: [String]?, ignoreIssues: Bool,
               issueManager: IssueManager?, maxJobs: Int?,
@@ -41,7 +43,8 @@ public struct SwiftCWrapper {
     self.arguments = swiftcArgs
     self.swiftcPath = swiftcPath
     self.stressTesterPath = stressTesterPath
-    self.astBuildLimit = astBuildLimit
+    self.requestLimit = requestLimit
+    self.requestLimitSeed = requestLimitSeed
     self.ignoreIssues = ignoreIssues
     self.issueManager = issueManager
     self.failFast = failFast
@@ -92,7 +95,8 @@ public struct SwiftCWrapper {
           StressTestOperation(file: file, rewriteMode: mode,
                               requests: requestKinds,
                               conformingMethodTypes: conformingMethodTypes,
-                              limit: astBuildLimit,
+                              limit: requestLimit,
+                              limitSeed: requestLimitSeed,
                               part: (part, of: partCount),
                               reportResponses: dumpResponsesPath != nil,
                               compilerArgs: arguments,

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapperTool.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapperTool.swift
@@ -63,7 +63,10 @@ public struct SwiftCWrapperTool {
     let suppressOutput = try suppressOutputEnv.get(from: environment) ?? false
     let astBuildLimit = try astBuildLimitEnv.get(from: environment)
     let rewriteModes = try rewriteModesEnv.get(from: environment) ?? [.none, .concurrent, .insideOut]
-    let requestKinds = RequestKind.reduce(try requestKindsEnv.get(from: environment) ?? [.ide])
+    let requestKinds = RequestKind.reduce(
+      try requestKindsEnv.get(from: environment) ??
+        [.cursorInfo, .rangeInfo, .codeComplete, .collectExpressionType,
+         .format])
     let conformingMethodTypes = try conformingMethodTypesEnv.get(from: environment)
     let maxJobs = try maxJobsEnv.get(from: environment)
     let dumpResponsesPath = try dumpResponsesPathEnv.get(from: environment)

--- a/SourceKitStressTester/Tests/StressTesterToolTests/StressTesterToolTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/StressTesterToolTests.swift
@@ -33,11 +33,18 @@ class StressTesterToolTests: XCTestCase {
     // FIXME: Add back in when validate is back to normal
     // XCTAssertThrowsError(try StressTesterTool.parse([testFile.path, "--", "anything"]))
 
+    // Limit seed with no limit
+    XCTAssertThrowsError(try StressTesterTool.parse(["--limit-seed 10"] + valid))
+
+    // Limit and page with no seed
+    XCTAssertThrowsError(try StressTesterTool.parse(["--limit 10 --page 1/4"] + valid))
+
     // Defaults
     StressTesterToolTests.assertParse(valid) { defaults in
       XCTAssertEqual(defaults.rewriteMode, .none)
       XCTAssertEqual(defaults.format, .humanReadable)
       XCTAssertEqual(defaults.limit, nil)
+      XCTAssertEqual(defaults.limitSeed, nil)
       XCTAssertEqual(defaults.page, Page())
       XCTAssertEqual(defaults.requests, [.ide])
       XCTAssertEqual(defaults.dryRun, false)
@@ -53,33 +60,34 @@ class StressTesterToolTests: XCTestCase {
       "--rewrite-mode", "basic",
       "--format", "json",
       "--limit", "1",
+      "--limit-seed", "3",
       "--page", "2/5",
       "--request", "CursorInfo", "--request", "CODECOMPLETE",
       "--dry-run",
       "--report-responses",
       "--type-list-item", "foo", "--type-list-item", "bar",
       "--temp-dir", workspace.path,
-      "--swiftc", swiftcPath,
-      testFile.path, "--", testFile.path
-    ]
+      "--swiftc", swiftcPath
+    ] + valid
     let allShort: [String] = [
       "-m", "basic",
       "-f", "json",
       "-l", "1",
+      "--limit-seed", "3", // no short
       "-p", "2/5",
       "-r", "CursorInfo", "-r", "CODECOMPLETE",
       "-d",
       "--report-responses", // no short
       "-t", "foo", "-t", "bar",
       "--temp-dir", workspace.path, // no short
-      "-s", swiftcPath,
-      testFile.path, "--", testFile.path
-    ]
+      "-s", swiftcPath
+    ] + valid
     let assertValid = { [workspace, swiftcPath, testFile] (args: [String]) in
       StressTesterToolTests.assertParse(args) { tool in
         XCTAssertEqual(tool.rewriteMode, .basic)
         XCTAssertEqual(tool.format, .json)
         XCTAssertEqual(tool.limit, 1)
+        XCTAssertEqual(tool.limitSeed, 3)
         XCTAssertEqual(tool.page, Page(2, of: 5))
         XCTAssertEqual(tool.requests, [.cursorInfo, .codeComplete])
         XCTAssertEqual(tool.dryRun, true)

--- a/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
+++ b/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
@@ -256,9 +256,10 @@ class SwiftCWrapperToolTests: XCTestCase {
     try? FileManager.default.removeItem(at: workspace)
   }
 
-  private func assertInvocationsMatch(invocations: [Substring],
-                                      rewriteModes: [RewriteMode],
-                                      requestKinds: [RequestKind] = RequestKind.ideRequests) {
+  private func assertInvocationsMatch(
+    invocations: [Substring], rewriteModes: [RewriteMode],
+    requestKinds: [RequestKind] = [.cursorInfo, .rangeInfo, .codeComplete,
+                                   .collectExpressionType, .format]) {
     for invocation in invocations {
       XCTAssertTrue(invocation.contains("--format json"),
                     "Missing json format in '\(invocation)'")


### PR DESCRIPTION
Replace the AST build limit with a new request limit option. The AST
build limit would run the first N requests based on whether the AST was
rebuilt for that request or not.

The new option instead picks a random distribution of requests across,
ensuring a wider range of file coverage.