### PR TITLE
Continue running the stress tester after an error is encountered

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -21,6 +21,7 @@ if let sourcekitSearchPathPointer = getenv("SWIFT_STRESS_TESTER_SOURCEKIT_SEARCH
 
 let package = Package(
   name: "SourceKitStressTester",
+  platforms: [.macOS(.v10_12)],
   products: [
     .executable(name: "sk-stress-test", targets: ["sk-stress-test"]),
     .executable(name: "sk-swiftc-wrapper", targets: ["sk-swiftc-wrapper"]),

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -457,9 +457,10 @@ class SourceKitDocument {
     case .timedOut:
       /// We timed out waiting for the response. Any following requests would
       /// not be executed by SourceKit until this one finishes. To avoid this,
-      /// and since we don't have cancellation support in SourceKit, set up a
-      /// new connection that is free to execute requests.
-      connection.restart()
+      /// and since we don't have cancellation support in SourceKit, crash the
+      /// current SourceKitService so we get a new instance that isn't
+      /// processing any requests.
+      connection.crash()
       throw SourceKitError.timedOut(request: info)
     }
   }

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -15,7 +15,7 @@ import SwiftSyntax
 import Common
 import Foundation
 
-struct SourceKitDocument {
+class SourceKitDocument {
   let swiftc: String
   let args: CompilerArgs
   let tempDir: URL
@@ -58,13 +58,13 @@ struct SourceKitDocument {
     self.diagEngine.addConsumer(EmptyDiagConsumer())
   }
 
-  mutating func open(rewriteMode: RewriteMode) throws -> (SourceFileSyntax, SourceKitdResponse) {
+  func open(rewriteMode: RewriteMode) throws -> (SourceFileSyntax, SourceKitdResponse) {
     let source = try! String(contentsOf: args.forFile, encoding: .utf8)
     sourceState = SourceState(rewriteMode: rewriteMode, content: source)
     return try openOrUpdate(path: args.forFile.path)
   }
 
-  mutating func update(updateSource: (inout SourceState) -> Void) throws -> (SourceFileSyntax, SourceKitdResponse) {
+  func update(updateSource: (inout SourceState) -> Void) throws -> (SourceFileSyntax, SourceKitdResponse) {
     var sourceState = self.sourceState!
     try close()
     updateSource(&sourceState)
@@ -72,7 +72,7 @@ struct SourceKitDocument {
     return try openOrUpdate(source: sourceState.source)
   }
 
-  private mutating func openOrUpdate(path: String? = nil, source: String? = nil)
+  private func openOrUpdate(path: String? = nil, source: String? = nil)
   throws -> (SourceFileSyntax, SourceKitdResponse) {
     let request = SourceKitdRequest(uid: .request_EditorOpen)
     if let path = path {
@@ -96,7 +96,7 @@ struct SourceKitDocument {
   }
 
   @discardableResult
-  mutating func close() throws -> SourceKitdResponse {
+  func close() throws -> SourceKitdResponse {
     sourceState = nil
 
     let request = SourceKitdRequest(uid: .request_EditorClose)
@@ -363,7 +363,7 @@ struct SourceKitDocument {
     return (info, response)
   }
 
-  mutating func replaceText(offset: Int, length: Int, text: String) throws -> (SourceFileSyntax, SourceKitdResponse) {
+  func replaceText(offset: Int, length: Int, text: String) throws -> (SourceFileSyntax, SourceKitdResponse) {
     let request = SourceKitdRequest(uid: .request_EditorReplaceText)
     request.addParameter(.key_Name, value: args.forFile.path)
     request.addParameter(.key_Offset, value: offset)
@@ -500,7 +500,7 @@ struct SourceKitDocument {
   }
 
   @discardableResult
-  private mutating func updateSyntaxTree(request: RequestInfo) throws -> SourceFileSyntax {
+  private func updateSyntaxTree(request: RequestInfo) throws -> SourceFileSyntax {
     let tree: SourceFileSyntax
     do {
       tree = try parseSyntax(request: request)

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -406,7 +406,7 @@ class SourceKitDocument {
 
   private func shouldIgnoreArgs(of expected: ExpectedResult, for result: SourceKitdResponse.Dictionary) -> Bool {
     switch result.getUID(.key_Kind) {
-    case .kind_DeclStruct, .kind_DeclClass, .kind_DeclEnum, .kind_DeclTypeAlias:
+    case .kind_DeclStruct, .kind_DeclClass, .kind_DeclEnum, .kind_DeclTypeAlias, .kind_DeclGenericTypeParam:
       // Initializer calls look like function calls syntactically, but the
       // completion results only include the type name. Allow for that by
       // matching on the base name only.

--- a/SourceKitStressTester/Sources/SwiftCWrapper/FailFastOperationQueue.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/FailFastOperationQueue.swift
@@ -12,6 +12,8 @@
 
 import Foundation
 
+/// An operation queue that stops scheduling new operations as soon as the the
+/// completion handler returns `false`.
 public final class FailFastOperationQueue<Item: Operation> {
   private let serialQueue = DispatchQueue(label: "\(FailFastOperationQueue.self)")
   private let queue = OperationQueue()

--- a/SourceKitStressTester/Sources/SwiftCWrapper/StressTesterOperationQueue.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/StressTesterOperationQueue.swift
@@ -14,11 +14,11 @@ import Foundation
 
 /// An operation queue that stops scheduling new operations as soon as the the
 /// completion handler returns `false`.
-public final class FailFastOperationQueue<Item: Operation> {
-  private let serialQueue = DispatchQueue(label: "\(FailFastOperationQueue.self)")
+public final class StressTesterOperationQueue<Item: Operation> {
+  private let serialQueue = DispatchQueue(label: "\(StressTesterOperationQueue.self)")
   private let queue = OperationQueue()
   private let operations: [Item]
-  private let completionHandler: (Int, Item, Int, Int) -> Bool
+  private let completionHandler: (_ index: Int, _ operation: Item, _ operationsCompleted: Int, _ totalOperationCount: Int) -> Bool
 
   public init(operations: [Item], maxWorkers: Int? = nil,
        completionHandler: @escaping (Int, Item, Int, Int) -> Bool) {

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -134,7 +134,11 @@ public struct SwiftCWrapper {
       progress?.update(step: completed, total: total, text: message)
       orderingHandler?.complete(operation.responses, at: index, setLast: !operation.status.isPassed)
       operation.responses.removeAll()
-      return operation.status.isPassed
+      // We can control whether to stop scheduling new operations here. As long
+      // as we return `true`, the stress tester continues to schedule new
+      // test operations. To stop at the first failure, return
+      // `operation.status.isPassed`.
+      return true
     }
     queue.waitUntilFinished()
 
@@ -151,32 +155,41 @@ public struct SwiftCWrapper {
 
     // Determine the set of processed files and the first failure (if any)
     var processedFiles = Set<String>()
-    var detectedIssue: StressTesterIssue? = nil
-    for operation in operations where detectedIssue == nil {
+    var detectedIssues: [StressTesterIssue] = []
+    for operation in operations {
       switch operation.status {
       case .cancelled:
         fatalError("cancelled operation before failed operation")
       case .unexecuted:
         fatalError("unterminated operation")
       case .errored(let status):
-        detectedIssue = .errored(status: status, file: operation.file,
-                                 arguments: escapeArgs(operation.args))
-      case .failed(let sourceKitError):
-        detectedIssue = .failed(sourceKitError: sourceKitError,
-                                arguments: escapeArgs(operation.args))
+        detectedIssues.append(.errored(status: status, file: operation.file,
+                                 arguments: escapeArgs(operation.args)))
+      case .failed(let sourceKitErrors):
+        for sourceKitError in sourceKitErrors {
+          detectedIssues.append(.failed(sourceKitError: sourceKitError,
+                                  arguments: escapeArgs(operation.args)))
+        }
         fallthrough
       case .passed:
         processedFiles.insert(operation.file)
       }
     }
 
-    let matchingSpec = try issueManager?.update(for: processedFiles, issue: detectedIssue)
-    try report(detectedIssue, matching: matchingSpec)
+    var hasUnexpectedIssue = false
+    for detectedIssue in detectedIssues {
+      let matchingSpec = try issueManager?.update(for: processedFiles, issue: detectedIssue)
+      if matchingSpec != nil {
+        hasUnexpectedIssue = true
+      }
+      try report(detectedIssue, matching: matchingSpec)
+    }
 
-    if detectedIssue == nil || matchingSpec != nil {
+    if hasUnexpectedIssue {
+      return ignoreIssues ? swiftcResult.status : EXIT_FAILURE
+    } else {
       return EXIT_SUCCESS
     }
-    return ignoreIssues ? swiftcResult.status : EXIT_FAILURE
   }
 
   private func writeResponseData(_ responses: [SourceKitResponseData], to path: String, seenResponses: inout Set<UInt64>) {

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -129,7 +129,7 @@ public struct SwiftCWrapper {
       }
     }
 
-    let queue = FailFastOperationQueue(operations: operations, maxWorkers: maxJobs) { index, operation, completed, total -> Bool in
+    let queue = StressTesterOperationQueue(operations: operations, maxWorkers: maxJobs) { index, operation, completed, total -> Bool in
       let message = "\(operation.file) (\(operation.summary)): \(operation.status.name)"
       progress?.update(step: completed, total: total, text: message)
       orderingHandler?.complete(operation.responses, at: index, setLast: !operation.status.isPassed)
@@ -179,7 +179,7 @@ public struct SwiftCWrapper {
     var hasUnexpectedIssue = false
     for detectedIssue in detectedIssues {
       let matchingSpec = try issueManager?.update(for: processedFiles, issue: detectedIssue)
-      if matchingSpec != nil {
+      if issueManager == nil || matchingSpec != nil {
         hasUnexpectedIssue = true
       }
       try report(detectedIssue, matching: matchingSpec)

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -226,7 +226,7 @@ public struct SwiftCWrapper {
                                     config: issueManager.activeConfig)
         let json = try issueManager.encoder.encode(xfail)
         stderrStream <<< "Add the following entry to the expected failures JSON file to mark it as expected:\n"
-        stderrStream <<< json <<< "\n\n"
+        stderrStream <<< String(data: json, encoding: .utf8)! <<< "\n\n"
       }
     }
   }

--- a/SourceKitStressTester/Sources/SwiftSourceKit/SourcekitdClient.swift
+++ b/SourceKitStressTester/Sources/SwiftSourceKit/SourcekitdClient.swift
@@ -13,21 +13,127 @@
 //===----------------------------------------------------------------------===//
 
 import sourcekitd
+import Dispatch
+
+/// An empty object to generate unique `ObjectIdentifier`s.
+fileprivate class Object {}
 
 public class SourceKitdService {
 
-  public init() {
-    sourcekitd_initialize()
+  enum State {
+    case running
+    case interrupted
+    case semaDisabled
   }
+
+  /// The queue that makes sure only one request is executed at a time
+  private let requestQueue = DispatchQueue(label: "SourceKitdService.requestQueue", qos: .userInitiated)
+
+  /// The queue that guards access to the `state` and `stateChangeHandlers` variables
+  private let stateQueue = DispatchQueue(label: "SourceKitdService.stateQueue", qos: .userInitiated)
+
+  private var state: State = .running {
+    didSet {
+      dispatchPrecondition(condition: .onQueue(stateQueue))
+      for handler in stateChangeHandlers.values {
+        handler()
+      }
+    }
+  }
+
+  /// Handlers to be executed whenever the `state` changes.
+  private var stateChangeHandlers: [ObjectIdentifier: () -> Void] = [:]
+
+  public init() {
+    initializeService()
+  }
+
+  /// Set up a new SourceKit service instance.
+  private func initializeService() {
+    sourcekitd_initialize()
+    sourcekitd_set_notification_handler { [self] resp in
+      let response = SourceKitdResponse(resp: resp!)
+
+      stateQueue.async {
+        if self.state == .interrupted {
+          self.state = .semaDisabled
+
+          // sourcekitd came back online. Poke it to restore semantic
+          // functionality. Intentionally don't execute this request on the
+          // request queue because request order doesn't matter for this
+          // pseudo-document and we want it to be executed immediately, even if
+          // the request queue is blocked.
+          let request = SourceKitdRequest(uid: .request_CursorInfo)
+          request.addParameter(.key_SourceText, value: "")
+          _ = sourcekitd_send_request_sync(request.rawRequest)
+        }
+
+        if response.isConnectionInterruptionError {
+          self.state = .interrupted
+        } else if response.notificationType == .semaDisabledNotification {
+          self.state = .semaDisabled
+        } else if response.notificationType == .semaEnabledNotification {
+          self.state = .running
+        }
+      }
+    }
+  }
+
   deinit {
     sourcekitd_shutdown()
+  }
+
+  /// Restarts the service. This is a workaround to set up a new service in case
+  /// we time out waiting for a request response and we want to handle it.
+  /// Replace by proper cancellation once we have cancellation support in
+  /// SourceKit.
+  public func restart() {
+    sourcekitd_shutdown()
+    // We need to wait for the old service to fully shut down before we can
+    // create a new one but we don't receive a notification when the old service
+    // did shut down. Waiting for a second seems to give it enough time.
+    sleep(1)
+    initializeService()
+    stateQueue.sync {
+      self.state = .running
+    }
+  }
+
+  /// Execute `callback` one this service is in `desiredState`
+  private func waitForState(_ desiredState: State, callback: @escaping () -> Void) {
+    stateQueue.async { [self] in
+      if state == desiredState {
+        callback()
+      } else {
+        let identifier = ObjectIdentifier(Object())
+        stateChangeHandlers[identifier] = { [self] in
+          dispatchPrecondition(condition: .onQueue(stateQueue))
+          if state == desiredState {
+            callback()
+            stateChangeHandlers[identifier] = nil
+          }
+        }
+      }
+    }
+  }
+
+  /// Block the current thread until this service is in `desiredState`.
+  private func blockUntilState(_ desiredState: State) {
+    let semaphore = DispatchSemaphore(value: 0)
+    waitForState(desiredState) {
+      semaphore.signal()
+    }
+    semaphore.wait()
   }
 
   /// Send a request synchronously with a handler for its response.
   /// - Parameter request: The request to send.
   /// - Returns: The response from the sourcekitd service.
   public func sendSyn(request: SourceKitdRequest) -> SourceKitdResponse {
-    return SourceKitdResponse(resp: sourcekitd_send_request_sync(request.rawRequest))
+    return requestQueue.sync {
+      blockUntilState(.running)
+      return SourceKitdResponse(resp: sourcekitd_send_request_sync(request.rawRequest))
+    }
   }
 
   /// Send a request asynchronously with a handler for its response.
@@ -35,9 +141,18 @@ public class SourceKitdService {
   /// - Parameter handler: The handler for the response in the future.
   public func send(request: SourceKitdRequest,
                    handler: @escaping (SourceKitdResponse) -> ())  {
-    sourcekitd_send_request(request.rawRequest, nil) { response in
-      guard let response = response else { return }
-      handler(SourceKitdResponse(resp: response))
+    requestQueue.async { [self] in
+      blockUntilState(.running)
+      let response = SourceKitdResponse(resp: sourcekitd_send_request_sync(request.rawRequest))
+      if response.isConnectionInterruptionError {
+        // Set the state into the interrupted state now. We will also catch this
+        // in the notification handler but that has some delay and we might be
+        // scheduling new requests before the state is set to `interrupted`.
+        stateQueue.sync {
+          self.state = .interrupted
+        }
+      }
+      handler(response)
     }
   }
 }

--- a/SourceKitStressTester/Sources/SwiftSourceKit/SourcekitdClient.swift
+++ b/SourceKitStressTester/Sources/SwiftSourceKit/SourcekitdClient.swift
@@ -83,19 +83,15 @@ public class SourceKitdService {
     sourcekitd_shutdown()
   }
 
-  /// Restarts the service. This is a workaround to set up a new service in case
+  /// Crash the service. This is a workaround to set up a new service in case
   /// we time out waiting for a request response and we want to handle it.
   /// Replace by proper cancellation once we have cancellation support in
   /// SourceKit.
-  public func restart() {
-    sourcekitd_shutdown()
-    // We need to wait for the old service to fully shut down before we can
-    // create a new one but we don't receive a notification when the old service
-    // did shut down. Waiting for a second seems to give it enough time.
-    sleep(1)
-    initializeService()
+  public func crash() {
+    let request = SourceKitdRequest(uid: .request_CrashWithExit)
+    _ = sourcekitd_send_request_sync(request.rawRequest)
     stateQueue.sync {
-      self.state = .running
+      self.state = .interrupted
     }
   }
 

--- a/SourceKitStressTester/Sources/SwiftSourceKit/SourcekitdResponse.swift
+++ b/SourceKitStressTester/Sources/SwiftSourceKit/SourcekitdResponse.swift
@@ -213,6 +213,10 @@ public class SourceKitdResponse: CustomStringConvertible {
 
   private let resp: sourcekitd_response_t
 
+  public var isNull: Bool {
+    return sourcekitd_variant_get_type(sourcekitd_response_get_value(resp)).rawValue == SOURCEKITD_VARIANT_TYPE_NULL.rawValue
+  }
+
   public var value: Dictionary {
     return Dictionary(dict: sourcekitd_response_get_value(resp), context: self)
   }
@@ -232,6 +236,18 @@ public class SourceKitdResponse: CustomStringConvertible {
   /// Whether or not this response represents a notification.
   public var isNotification: Bool {
     return value.getOptional(.key_Notification) != nil
+  }
+
+  /// If this is a notification return the type of the notification, otherwise
+  /// `nil`.
+  public var notificationType: SourceKitdUID? {
+    if isNull {
+      return nil
+    }
+    guard let notification = value.getOptional(.key_Notification)?.getUID() else {
+      return nil
+    }
+    return notification
   }
 
   /// Whether or not this response represents a connection interruption error.

--- a/SourceKitStressTester/Sources/SwiftSourceKit/UIDs.swift
+++ b/SourceKitStressTester/Sources/SwiftSourceKit/UIDs.swift
@@ -376,5 +376,9 @@ extension SourceKitdUID {
   public static let kind_SyntaxTreeSerializationByteTree = SourceKitdUID(string: "source.syntaxtree.serialization.format.bytetree")
 
   public static let compilerCrashedNotification = SourceKitdUID(string: "notification.toolchain-compiler-crashed")
+  public static let semaDisabledNotification = SourceKitdUID(string:
+      "source.notification.sema_disabled")
+  public static let semaEnabledNotification = SourceKitdUID(string:
+      "source.notification.sema_enabled")
   public static let source_notification_editor_documentupdate = SourceKitdUID(string: "source.notification.editor.documentupdate")
 }

--- a/SourceKitStressTester/Sources/sk-stress-test/main.swift
+++ b/SourceKitStressTester/Sources/sk-stress-test/main.swift
@@ -11,5 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import StressTester
+import Dispatch
 
-StressTesterTool.main()
+DispatchQueue.main.async {
+  StressTesterTool.main()
+}
+dispatchMain()

--- a/SourceKitStressTester/Tests/StressTesterToolTests/StressTesterToolTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/StressTesterToolTests.swift
@@ -114,15 +114,15 @@ class StressTesterToolTests: XCTestCase {
                                       tempDir: workspace,
                                       responseHandler: { responseData in
                                         responses.append(responseData)
-                                      })
+    })
 
     let tester = StressTester(options: options)
-    XCTAssertNoThrow(try tester.run(swiftc: swiftcPath,
-                                    compilerArgs: CompilerArgs(
-                                      for: testFile,
-                                      args: [CompilerArg(testFile.path)],
-                                      tempDir: workspace)),
-                     "no sourcekitd crashes in test program")
+    let errors = tester.run(swiftc: swiftcPath,
+                            compilerArgs: CompilerArgs(
+                              for: testFile,
+                                 args: [CompilerArg(testFile.path)],
+                                 tempDir: workspace))
+    XCTAssert(errors.isEmpty, "no sourcekitd crashes in test program")
     XCTAssertFalse(responses.isEmpty, "produces responses")
     XCTAssertTrue(responses.allSatisfy { response in
       if case .codeComplete = response.request { return true }
@@ -150,11 +150,12 @@ class StressTesterToolTests: XCTestCase {
 
     let tester = StressTester(options: options)
     // Expect interface request to fail since no module will be generated
-    XCTAssertThrowsError(try tester.run(swiftc: swiftc.file.path,
-                                        compilerArgs: CompilerArgs(
-                                          for: testFile,
-                                          args: args,
-                                          tempDir: workspace)))
+    let errors = tester.run(swiftc: swiftc.file.path,
+                            compilerArgs: CompilerArgs(
+                              for: testFile,
+                                 args: args,
+                                 tempDir: workspace))
+    XCTAssert(errors.count == 1)
 
     let invocations = swiftc.retrieveInvocations()
     let expectedInvocation = "-Xfrontend -experimental-allow-module-with-compiler-errors -emit-module -module-name Test -emit-module-path \(workspace.appendingPathComponent("Test.swiftmodule").path) -"

--- a/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
+++ b/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
@@ -75,7 +75,7 @@ class SwiftCWrapperToolTests: XCTestCase {
     }
   }
 
-  func testFailFastOperationQueue() throws {
+  func testStressTesterOperationQueue() throws {
     class TestOperation: Operation {
       var waitCount: Int
 
@@ -96,13 +96,13 @@ class SwiftCWrapperToolTests: XCTestCase {
     let third = TestOperation(waitCount: 20)
     let fourth = TestOperation(waitCount: 30)
 
-    FailFastOperationQueue(operations: [first, second, third, fourth], maxWorkers: 2, completionHandler: { _, finishedOp, _, _ in
+    StressTesterOperationQueue(operations: [first, second, third, fourth], maxWorkers: 2, completionHandler: { _, finishedOp, _, _ in
       // cancel later operations when the second operation completes
       return finishedOp !== second
     }).waitUntilFinished()
 
-    XCTAssertTrue(!first.isCancelled, "first was cancelled")
-    XCTAssertTrue(!second.isCancelled, "second was cancelled")
+    XCTAssertFalse(first.isCancelled, "first was cancelled")
+    XCTAssertFalse(second.isCancelled, "second was cancelled")
     XCTAssertTrue(third.isCancelled, "third wasn't cancelled")
     XCTAssertTrue(fourth.isCancelled, "fourth wasn't cancelled")
   }


### PR DESCRIPTION
The stress tester runs stable enough on the test suite now that a failure isn’t likely to cause a whole bunch of following failures.

Instead, continue running after a failures is encountered to get a more complete picture of the SourceKit issues in the source compatibility suite. The current behaviour of uncovering new issues after XFailed issues are fixed is annoying.