### PR TITLE
Retrieve the symbol graph during CursorInfo requests

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -143,6 +143,7 @@ struct SourceKitDocument {
     request.addParameter(.key_SourceFile, value: args.forFile.path)
     request.addParameter(.key_Offset, value: offset)
     request.addParameter(.key_RetrieveRefactorActions, value: 1)
+    request.addParameter(.key_RetrieveSymbolGraph, value: 1)
     request.addCompilerArgs(args.sourcekitdArgs)
 
     let info = RequestInfo.cursorInfo(document: documentInfo, offset: offset,

--- a/SourceKitStressTester/Sources/SwiftSourceKit/UIDs.swift
+++ b/SourceKitStressTester/Sources/SwiftSourceKit/UIDs.swift
@@ -165,6 +165,7 @@ extension SourceKitdUID {
   public static let key_ExpressionOffset = SourceKitdUID(string: "key.expression_offset")
   public static let key_ExpressionLength = SourceKitdUID(string: "key.expression_length")
   public static let key_ExpressionType = SourceKitdUID(string: "key.expression_type")
+  public static let key_RetrieveSymbolGraph = SourceKitdUID(string: "key.retrieve_symbol_graph")
 
   public static let request_ProtocolVersion = SourceKitdUID(string: "source.request.protocol_version")
   public static let request_CompilerVersion = SourceKitdUID(string: "source.request.compiler_version")


### PR DESCRIPTION
Let’s also test that retrieving the symbol graph doesn’t crash.

Resolves rdar://77285086