### PR TITLE
Add a filter to sk-swiftc-wrapper to filter which files should be stress-tested

### DIFF
--- a/SourceKitStressTester/README.md
+++ b/SourceKitStressTester/README.md
@@ -48,6 +48,7 @@ SK_XFAILS_PATH=/tmp/xfails.json | The path to a JSON file that can be used to re
 SK_STRESS_ACTIVE_CONFIG=main | Entries in the SK_XFAILS_PATH file can include a list of applicable configurations. This variable indicates which configuration the current run represents, and will determine the subset of XFAIL entries that apply to this run.
 SK_STRESS_SUPPRESS_OUTPUT=1 | By default `sk-swiftc-wrapper` outputs progress and detected failures on stderr, as additional output on top of what the wrapper swiftc produced. Set this variable true to prevent this additional output. Results will still be output to the path specified by SK_STRESS_OUPUT.
 SK_STRESS_DUMP_RESPONSES_PATH=/tmp/responses.txt | If specified, all responses received from sourcekitd during stress testing will be written out to the provided path. This is useful for comparing the responses produced from different versions of sourcekitd. Note: to reduce file size, if a response is identical to one produced previously in the same run, a reference to the earlier response will be output instead.
+SK_STRESS_FILE_FILTER=/file.swift | Only stress test files that contain this filter. Other files will still be compiled, but not stress tested. Useful to reproduce a failure in a known file locally while wasting fewer resources. You will usually want to prepend a `/` to the file name to avoid e.g. `View.swift` matching `SomeView.swift`. 
 
 
 ## Stress testing sourcekitd with an existing Xcode project

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -85,6 +85,9 @@ public struct SwiftCWrapper {
 
     // Determine the list of stress testing operations to perform
     let operations = swiftFiles.flatMap { (file, sizeInBytes) -> [StressTestOperation] in
+      if let fileFilter = ProcessInfo.processInfo.environment["SK_STRESS_FILE_FILTER"], !file.contains(fileFilter) {
+        return []
+      }
       // Split large files into multiple parts to improve load balancing
       let partCount = max(Int(sizeInBytes / 1000), 1)
       return rewriteModes.flatMap { mode in


### PR DESCRIPTION
Add an environment variable `SK_STRESS_FILE_FILTER` with which the files that should be stress tested can be restricted.

This is super useful to reproduce a failure of the stress tester in CI locally, in which case you know which file fails to stress test and don’t want to also stress test the other files in the project.