### PR TITLE
Measure number of instructions each code completion request took

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
     ),
     .target(
       name: "StressTester",
-      dependencies: ["Common", "ArgumentParser", "SwiftSyntax", "SwiftSourceKit"],
+      dependencies: ["Common", "ArgumentParser", "SwiftSyntax", "SwiftSourceKit", "SwiftToolsSupport-auto"],
       swiftSettings: [.unsafeFlags(["-Fsystem", sourcekitSearchPath])],
       linkerSettings: [.unsafeFlags(["-Xlinker", "-F", "-Xlinker", sourcekitSearchPath])]
     ),

--- a/SourceKitStressTester/Sources/Common/Message.swift
+++ b/SourceKitStressTester/Sources/Common/Message.swift
@@ -72,6 +72,7 @@ public enum RequestInfo {
   case collectExpressionType(document: DocumentInfo, args: [String])
   case writeModule(document: DocumentInfo, args: [String])
   case interfaceGen(document: DocumentInfo, moduleName: String, args: [String])
+  case statistics
 }
 
 public struct DocumentInfo: Codable {
@@ -217,7 +218,7 @@ extension RequestInfo: Codable {
   enum BaseRequest: String, Codable {
     case editorOpen, editorClose, replaceText, format, cursorInfo, codeComplete,
       rangeInfo, semanticRefactoring, typeContextInfo, conformingMethodList,
-      collectExpressionType, writeModule, interfaceGen
+      collectExpressionType, writeModule, interfaceGen, statistics
   }
 
   public init(from decoder: Decoder) throws {
@@ -285,6 +286,8 @@ extension RequestInfo: Codable {
       let moduleName = try container.decode(String.self, forKey: .moduleName)
       let args = try container.decode([String].self, forKey: .args)
       self = .interfaceGen(document: document, moduleName: moduleName, args: args)
+    case .statistics:
+      self = .statistics
     }
   }
 
@@ -353,6 +356,8 @@ extension RequestInfo: Codable {
       try container.encode(document, forKey: .document)
       try container.encode(moduleName, forKey: .moduleName)
       try container.encode(args, forKey: .args)
+    case .statistics:
+      try container.encode(BaseRequest.statistics, forKey: .request)
     }
   }
 }
@@ -386,6 +391,8 @@ extension RequestInfo: CustomStringConvertible {
       return "WriteModule for \(document) with args: \(escapeArgs(args))"
     case .interfaceGen(let document, let moduleName, let args):
       return "InterfaceGen for \(document) compiled as \(moduleName) with args: \(escapeArgs(args))"
+    case .statistics:
+      return "SourceKit statistics"
     }
   }
 }
@@ -525,6 +532,8 @@ extension SourceKitError: CustomStringConvertible {
       return document.modification?.content
     case .interfaceGen(let document, _, _):
       return document.modification?.content
+    case .statistics:
+      return nil
     }
   }
 }
@@ -540,7 +549,7 @@ extension StressTesterMessage: CustomStringConvertible {
   }
 }
 
-public enum RequestKind: String, CaseIterable, CustomStringConvertible {
+public enum RequestKind: String, CaseIterable, CustomStringConvertible, Codable {
   case cursorInfo = "CursorInfo"
   case rangeInfo = "RangeInfo"
   case codeComplete = "CodeComplete"

--- a/SourceKitStressTester/Sources/StressTester/RequestDurationManager.swift
+++ b/SourceKitStressTester/Sources/StressTester/RequestDurationManager.swift
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Common
+import Foundation
+
+fileprivate extension Array where Element == Int {
+  /// Creates a logarithmic histogram. For each `key`, the `value` contains the
+  /// number of elements in this array that are smaller than `2 ^ key` but not
+  /// smaller than `2 ^ (key - 1)`.
+  var logHistogram: [Int: Int] {
+    var result: [Int: Int] = [:]
+    for value in self {
+      let log: Int
+      if value == 0 {
+        // We put 0 in bucket 0 even though it should be in -inf. But that's
+        // too hard to represent and we don't really care about 0 either.
+        log = 0
+      } else {
+        log = Int(log2(Double(value))) + 1
+      }
+      result[log, default: 0] += 1
+    }
+    return result
+  }
+}
+
+/// Captures aggregated information about executing a certain request kind on a
+/// certain file.
+struct AggregatedRequestDurations: Codable {
+  static let empty = AggregatedRequestDurations(instructionCounts: [])
+
+  /// The log histogram created by the extension on `Array` above
+  var logHistogram: [Int: Int]
+
+  /// The total number of instructions executed by the requests of this type
+  /// `totalInstructions` / `requestsExecuted` gives the average number of
+  /// instructions per request.
+  var totalInstructions: Int
+
+  /// The total number of requests of a given kind executed for a given file
+  var requestsExecuted: Int
+
+  init(instructionCounts: [Int]) {
+    logHistogram = instructionCounts.logHistogram
+    totalInstructions = instructionCounts.reduce(0, { $0 + $1 })
+    requestsExecuted = instructionCounts.count
+  }
+
+  mutating func merge(other: AggregatedRequestDurations) {
+    self.logHistogram.merge(other.logHistogram, uniquingKeysWith: {
+      $0 + $1
+    })
+    self.totalInstructions += other.totalInstructions
+    self.requestsExecuted += other.requestsExecuted
+  }
+}
+
+/// Contains aggregated information for all request kinds of all files executed
+/// by the stress tester.
+fileprivate struct RequestDurations: Codable {
+  // FIXME: We should be using `RequestKind` as the inner key but that causes
+  // the inner dictionary to be serialized as an array (rdar://78099769)
+  /// Maps file paths to request kinds to aggregated request duration information
+  var files: [String: [String: AggregatedRequestDurations]]
+}
+
+/// Collects the durations that requests executed by the stress tester took and
+/// writes them to `jsonFile` where the durations are collected together with
+/// all other stress tester runs.
+/// We are aggregating the results early (just keeping track of the average for
+/// each request type and a logarithmic histogram because keeping track of all
+/// request durations would result in a JSON file that is too large to handle
+/// easily.
+class RequestDurationManager {
+  /// The file that stores the request durations and that gets updated as new
+  /// aggregated information is added
+  let jsonFile: URL
+
+  init(jsonFile: URL) {
+    self.jsonFile = jsonFile
+  }
+
+  private func getRequestDurations() throws -> RequestDurations {
+    guard FileManager.default.fileExists(atPath: jsonFile.path) else {
+      return RequestDurations(files: [:])
+    }
+    let data = try Data(contentsOf: jsonFile)
+    return try JSONDecoder().decode(RequestDurations.self, from: data)
+  }
+
+  func add(aggregatedDurations: AggregatedRequestDurations, for file: String, requestKind: RequestKind) throws {
+    // FIXME: We are racing for the timings file here if two stress tester invocations try to update it simultaneously
+    var currentTimings = try getRequestDurations()
+    currentTimings.files[file, default: [:]][requestKind.rawValue, default: .empty].merge(other: aggregatedDurations)
+    let data = try JSONEncoder().encode(currentTimings)
+    try data.write(to: jsonFile, options: [.atomicWrite])
+  }
+}

--- a/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
@@ -65,6 +65,11 @@ public struct StressTesterTool: ParsableCommand {
   public var conformingMethodsTypeList: [String] = ["s:SQ", "s:SH"] // Equatable and Hashable
 
   @Option(name: .long,
+          help: "File to store aggregated measurements how long the SourceKit requests issued by the stress tester took",
+          transform: URL.init(fileURLWithPath:))
+  public var requestDurationsOutputFile: URL?
+
+  @Option(name: .long,
           help: "Path to a temporary directory to store intermediate modules",
           transform: URL.init(fileURLWithPath:))
   public var tempDir: URL?
@@ -133,6 +138,7 @@ public struct StressTesterTool: ParsableCommand {
       page: page,
       tempDir: tempDir!,
       astBuildLimit: limit,
+      requestDurationsOutputFile: requestDurationsOutputFile,
       responseHandler: !reportResponses ? nil :
         { [format] responseData in
           try StressTesterTool.report(

--- a/SourceKitStressTester/Sources/SwiftCWrapper/ExpectedIssue.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/ExpectedIssue.swift
@@ -103,6 +103,8 @@ public struct ExpectedIssue: Equatable, Codable {
     case .interfaceGen(let document, _, _):
       guard case .interfaceGen = issueDetail else { return false }
       return matchDocument(document)
+    case .statistics:
+      return false
     }
   }
 
@@ -211,6 +213,10 @@ public extension ExpectedIssue {
         path = document.path
         modification = document.modification?.summaryCode
         issueDetail = .interfaceGen
+      case .statistics:
+        path = "<statistics>"
+        modification = nil
+        issueDetail = .statistics
       }
     }
   }
@@ -230,6 +236,7 @@ public extension ExpectedIssue {
     case interfaceGen
     case semanticRefactoring(offset: Int?, refactoring: String?)
     case stressTesterCrash(status: Int32?, arguments: String?)
+    case statistics
 
     public init(from decoder: Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -284,6 +291,8 @@ public extension ExpectedIssue {
         self = .writeModule
       case .interfaceGen:
         self = .interfaceGen
+      case .statistics:
+        self = .statistics
       }
     }
 
@@ -332,6 +341,8 @@ public extension ExpectedIssue {
         try container.encode(RequestBase.writeModule, forKey: .kind)
       case .interfaceGen:
         try container.encode(RequestBase.interfaceGen, forKey: .kind)
+      case .statistics:
+        try container.encode(RequestBase.statistics, forKey: .kind)
       }
     }
 
@@ -342,6 +353,7 @@ public extension ExpectedIssue {
     private enum RequestBase: String, Codable {
       case editorOpen, editorClose, editorReplaceText
       case cursorInfo, codeComplete, rangeInfo, semanticRefactoring, typeContextInfo, conformingMethodList, collectExpressionType, format, writeModule, interfaceGen
+      case statistics
       case stressTesterCrash
     }
 
@@ -374,6 +386,8 @@ public extension ExpectedIssue {
       case .semanticRefactoring:
         return request == .cursorInfo || request == .rangeInfo
       case .stressTesterCrash:
+        return true
+      case .statistics:
         return true
       }
     }

--- a/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/StressTestOperation.swift
@@ -66,10 +66,13 @@ final class StressTestOperation: Operation {
   init(file: String, rewriteMode: RewriteMode, requests: Set<RequestKind>,
        conformingMethodTypes: [String]?, limit: Int?, part: (Int, of: Int),
        reportResponses: Bool, compilerArgs: [String], executable: String,
-       swiftc: String) {
+       swiftc: String, requestDurationsOutputFile: URL?) {
     var stressTesterArgs = ["--format", "json", "--page", "\(part.0)/\(part.of)", "--rewrite-mode", rewriteMode.rawValue]
     if let limit = limit {
       stressTesterArgs += ["--limit", String(limit)]
+    }
+    if let requestDurationsOutputFile = requestDurationsOutputFile {
+      stressTesterArgs += ["--request-durations-output-file", requestDurationsOutputFile.path]
     }
     stressTesterArgs += requests.flatMap { ["--request", $0.rawValue] }
     if let types = conformingMethodTypes {

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -21,6 +21,7 @@ public struct SwiftCWrapper {
   let swiftcPath: String
   let stressTesterPath: String
   let astBuildLimit: Int?
+  let requestDurationsOutputFile: URL?
   let rewriteModes: [RewriteMode]
   let requestKinds: Set<RequestKind>
   let conformingMethodTypes: [String]?
@@ -33,6 +34,7 @@ public struct SwiftCWrapper {
 
   public init(swiftcArgs: [String], swiftcPath: String,
               stressTesterPath: String, astBuildLimit: Int?,
+              requestDurationsOutputFile: URL?,
               rewriteModes: [RewriteMode], requestKinds: Set<RequestKind>,
               conformingMethodTypes: [String]?, ignoreIssues: Bool,
               issueManager: IssueManager?, maxJobs: Int?,
@@ -46,6 +48,7 @@ public struct SwiftCWrapper {
     self.issueManager = issueManager
     self.failFast = failFast
     self.suppressOutput = suppressOutput
+    self.requestDurationsOutputFile = requestDurationsOutputFile
     self.rewriteModes = rewriteModes
     self.requestKinds = requestKinds
     self.conformingMethodTypes = conformingMethodTypes
@@ -100,7 +103,8 @@ public struct SwiftCWrapper {
                               reportResponses: dumpResponsesPath != nil,
                               compilerArgs: arguments,
                               executable: stressTesterPath,
-                              swiftc: swiftcPath)
+                              swiftc: swiftcPath,
+                              requestDurationsOutputFile: requestDurationsOutputFile)
         }
       }
     }

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapperTool.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapperTool.swift
@@ -31,6 +31,8 @@ public struct SwiftCWrapperTool {
     let ignoreIssuesEnv = EnvOption("SK_STRESS_SILENT", type: Bool.self)
     /// Limit the number of sourcekit requests made per-file based on the number of AST rebuilds they trigger
     let astBuildLimitEnv = EnvOption("SK_STRESS_AST_BUILD_LIMIT", type: Int.self)
+    /// A file in which measurements how long the SourceKit requests issued by the stress tester took, should be aggregated
+    let requestDurationsOutputFileEnv = EnvOption("SK_STRESS_REQUEST_DURATIONS_FILE", type: String.self)
     /// Output only what the wrapped compiler outputs
     let suppressOutputEnv = EnvOption("SK_STRESS_SUPPRESS_OUTPUT", type: Bool.self)
     /// Non-default space-separated list of rewrite modes to use
@@ -62,6 +64,7 @@ public struct SwiftCWrapperTool {
     let ignoreIssues = try ignoreIssuesEnv.get(from: environment) ?? false
     let suppressOutput = try suppressOutputEnv.get(from: environment) ?? false
     let astBuildLimit = try astBuildLimitEnv.get(from: environment)
+    let requestDurationsOutputFile = try requestDurationsOutputFileEnv.get(from: environment).map(URL.init(fileURLWithPath:))
     let rewriteModes = try rewriteModesEnv.get(from: environment) ?? [.none, .concurrent, .insideOut]
     let requestKinds = RequestKind.reduce(try requestKindsEnv.get(from: environment) ?? [.ide])
     let conformingMethodTypes = try conformingMethodTypesEnv.get(from: environment)
@@ -84,6 +87,7 @@ public struct SwiftCWrapperTool {
                                 swiftcPath: swiftc,
                                 stressTesterPath: stressTester,
                                 astBuildLimit: astBuildLimit,
+                                requestDurationsOutputFile: requestDurationsOutputFile,
                                 rewriteModes: rewriteModes,
                                 requestKinds: requestKinds,
                                 conformingMethodTypes: conformingMethodTypes,

--- a/SourceKitStressTester/Sources/SwiftSourceKit/UIDs.swift
+++ b/SourceKitStressTester/Sources/SwiftSourceKit/UIDs.swift
@@ -368,6 +368,7 @@ extension SourceKitdUID {
   public static let kind_Unknown = SourceKitdUID(string: "source.syntacticrename.unknown")
   public static let kind_StatNumRequests = SourceKitdUID(string: "source.statistic.num-requests")
   public static let kind_StatNumSemaRequests = SourceKitdUID(string: "source.statistic.num-semantic-requests")
+  public static let kind_StatInstructionCount = SourceKitdUID(string: "source.statistic.instruction-count")
   public static let kind_SyntaxTreeOff = SourceKitdUID(string: "source.syntaxtree.transfer.off")
   public static let kind_SyntaxTreeIncremental = SourceKitdUID(string: "source.syntaxtree.transfer.incremental")
   public static let kind_SyntaxTreeFull = SourceKitdUID(string: "source.syntaxtree.transfer.full")

--- a/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
+++ b/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
@@ -111,7 +111,8 @@ class SwiftCWrapperToolTests: XCTestCase {
     func getSwiftFiles(from list: [String]) -> [String] {
       let wrapper: SwiftCWrapper = SwiftCWrapper(
         swiftcArgs: list, swiftcPath: "", stressTesterPath: "",
-        astBuildLimit: nil, rewriteModes: [], requestKinds: Set(),
+        astBuildLimit: nil, requestDurationsOutputFile: nil,
+        rewriteModes: [], requestKinds: Set(),
         conformingMethodTypes: nil, ignoreIssues: false, issueManager: nil,
         maxJobs: nil, dumpResponsesPath: nil, failFast: false,
         suppressOutput: false)


### PR DESCRIPTION
Depends on https://github.com/apple/swift/pull/37450

-------

Use the new `key.enable_instruction_counter` option to measure how many instructions were executed for each code completion request. Write the results into a JSON file that can be post-analysed for average request duration, slowest files etc.

Since outputting all request information and durations to a file would generate a result file that is too big to post-process efficiently, the idea here is that the stress tester already does a fair amount of pre-processing and only writes out aggregated results. Once we’ve discovered slow files that should be fixed, we’d need to reproduce the slow behaviour locally to gather more detailed information.

It’s quite possible that we’ll also need to add flags to the stress tester to output more detailed information for a single file (e.g. completion duration at each offset at a given rewrite stage), but we can see what would be useful there once we get to it.

------

Eventually, with https://github.com/apple/swift-source-compat-suite/pull/539 merged, this will allow us to time the duration code completion requests took in the stress tester and generate an analysis like the following.

<details>
<summary>Output</summary>

```
IMPORTANT:
All measurements printed by this script were done in number of number of
instructions. Measurements in seconds are computed assuming that all machines
execute the same number of instructions per second at all times, which is not
correct. Thus all measurements in seconds should be taken with extreme care.
As they scale linearly with the number of instructions, it is safe to compare
values in seconds output by this script.

---------- All CodeComplete requests ----------

Average: 3e+08 instr (ca. 0.048s)

Histogram:
< 8e+06 instr (ca.  0.001s): ***                                       6.1% (<   6.1%)
< 2e+07 instr (ca.  0.003s): **                                        5.1% (<  11.2%)
< 3e+07 instr (ca.  0.005s):                                           0.8% (<  11.9%)
< 7e+07 instr (ca.  0.010s): *******                                  13.0% (<  24.9%)
< 1e+08 instr (ca.  0.020s):                                           0.0% (<  24.9%)
< 3e+08 instr (ca.  0.040s): **                                        4.7% (<  29.6%)
< 5e+08 instr (ca.  0.080s): **************************************** 68.3% (<  98.0%)
< 1e+09 instr (ca.  0.160s):                                           0.5% (<  98.4%)
< 2e+09 instr (ca.  0.321s):                                           1.5% (<  99.9%)
< 4e+09 instr (ca.  0.642s):                                           0.1% (<  99.9%)
< 9e+09 instr (ca.  1.283s):                                           0.1% (< 100.0%)

---------- 10 slowest files for CodeComplete requests ----------

-- /Users/alex/swift-src/swift-source-compat-suite/project_cache/Dollar/Sources/Dollar.swift --

Average: 4e+08 instr (ca. 0.058s)

Histogram:
< 2e+07 instr (ca.  0.003s): *******                                  11.0% (<  11.0%)
< 3e+07 instr (ca.  0.005s): ****                                      6.2% (<  17.2%)
< 7e+07 instr (ca.  0.010s): ****                                      6.2% (<  23.3%)
< 1e+08 instr (ca.  0.020s):                                           0.0% (<  23.3%)
< 3e+08 instr (ca.  0.040s): *******                                  10.6% (<  33.9%)
< 5e+08 instr (ca.  0.080s): **************************************** 58.6% (<  92.5%)
< 1e+09 instr (ca.  0.160s): **                                        4.0% (<  96.5%)
< 2e+09 instr (ca.  0.321s): *                                         2.6% (<  99.1%)
< 4e+09 instr (ca.  0.642s):                                           0.4% (<  99.6%)
< 9e+09 instr (ca.  1.283s):                                           0.4% (< 100.0%)

-- /Users/alex/swift-src/swift-source-compat-suite/project_cache/Dollar/Sources/AutoBind.swift --

Average: 4e+08 instr (ca. 0.054s)

Histogram:
< 8e+06 instr (ca.  0.001s):                                           1.7% (<   1.7%)
< 2e+07 instr (ca.  0.003s):                                           0.9% (<   2.6%)
< 3e+07 instr (ca.  0.005s):                                           0.0% (<   2.6%)
< 7e+07 instr (ca.  0.010s): ****                                      8.4% (<  11.0%)
< 1e+08 instr (ca.  0.020s):                                           0.0% (<  11.0%)
< 3e+08 instr (ca.  0.040s): ***                                       7.1% (<  18.1%)
< 5e+08 instr (ca.  0.080s): **************************************** 80.4% (<  98.6%)
< 1e+09 instr (ca.  0.160s):                                           0.0% (<  98.6%)
< 2e+09 instr (ca.  0.321s):                                           1.4% (< 100.0%)

-- /Users/alex/swift-src/swift-source-compat-suite/project_cache/Dollar/Sources/AutoCurry.swift --

Average: 3e+08 instr (ca. 0.041s)

Histogram:
< 8e+06 instr (ca.  0.001s): *******                                  11.7% (<  11.7%)
< 2e+07 instr (ca.  0.003s): ****                                      7.2% (<  18.9%)
< 3e+07 instr (ca.  0.005s):                                           0.0% (<  18.9%)
< 7e+07 instr (ca.  0.010s): ************                             18.9% (<  37.8%)
< 1e+08 instr (ca.  0.020s):                                           0.0% (<  37.8%)
< 3e+08 instr (ca.  0.040s):                                           1.1% (<  38.9%)
< 5e+08 instr (ca.  0.080s): **************************************** 60.0% (<  98.8%)
< 1e+09 instr (ca.  0.160s):                                           0.0% (<  98.8%)
< 2e+09 instr (ca.  0.321s):  
```
</details>