### PR TITLE
Update test modules to skip function bodies and use WMO

### DIFF
--- a/SourceKitStressTester/Sources/Common/CompilerArgs.swift
+++ b/SourceKitStressTester/Sources/Common/CompilerArgs.swift
@@ -32,12 +32,15 @@ public struct CompilerArg: Equatable {
 
 public struct CompilerArgs {
   private static let SKIP_FLAGS: Set = [
-    "-whole-module-optimization",
-    "-incremental"
+    "-incremental",
+    "-enable-batch-mode",
+    "-emit-object", "-c"
   ]
   private static let SKIP_OPTIONS: Set = [
     "-num-threads",
-    "-output-file-map"
+    "-output-file-map",
+    "-module-name",
+    "-emit-module-path", "-o"
   ]
 
   /// Main file intended to be compiled
@@ -50,10 +53,10 @@ public struct CompilerArgs {
   /// arguments found in those files
   public let sourcekitdArgs: [String]
 
-  /// Original arguments but with flags/options relating to multi-module
-  /// output removed, as well as any references to fileToCompile. This
-  /// includes replacing any file list with a new file when they contain the
-  /// fileToCompile
+  /// Original arguments but with references to `forFile` removed. This
+  /// includes replacing any file list with a new file when it contains
+  /// `forFile`. Arguments relating to incremental compilation or the output
+  /// of the module are also removed.
   public let processArgs: [String]
 
   public init(for file: URL, args: [CompilerArg], tempDir: URL) {

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -28,7 +28,7 @@ struct SourceKitDocument {
   private var converter: SourceLocationConverter? = nil
 
   private var tempModulePath: URL {
-    tempDir.appendingPathComponent("Test.swiftmodule")
+    tempDir.appendingPathComponent("TestModForStressTester.swiftmodule")
   }
 
   private var documentInfo: DocumentInfo {
@@ -323,7 +323,11 @@ struct SourceKitDocument {
 
     let moduleName = tempModulePath.deletingPathExtension().lastPathComponent
     let compilerArgs = self.args.processArgs + [
+      // Merge modules ends up about the same speed as WMO when skipping
+      // function bodies
+      "-whole-module-optimization",
       "-Xfrontend", "-experimental-allow-module-with-compiler-errors",
+      "-Xfrontend", "-experimental-skip-all-function-bodies",
       "-emit-module", "-module-name", moduleName, "-emit-module-path",
       tempModulePath.path,
       "-"
@@ -346,8 +350,10 @@ struct SourceKitDocument {
     let moduleDir = tempModulePath.deletingLastPathComponent()
     let moduleName = tempModulePath.deletingPathExtension().lastPathComponent
     let interfaceFile = moduleDir.appendingPathComponent("<interface-gen>")
-    let compilerArgs = self.args.sourcekitdArgs +
-      ["-I\(moduleDir.path)"]
+    let compilerArgs = self.args.sourcekitdArgs + [
+      "-I\(moduleDir.path)",
+       "-Xfrontend", "-experimental-allow-module-with-compiler-errors"
+    ]
 
     let request = SourceKitdRequest(uid: .request_EditorOpenInterface)
     request.addParameter(.key_SourceFile, value: args.forFile.path)


### PR DESCRIPTION
There's little performance benefit (if any) in using an incremental
build with all function bodies skipped, so just use WMO instead to match
the index arena builds.

Also skip "-emit-object" (and its alias) since skipping all function
bodies is incompatible with code generation.