### PR TITLE
Mark expected failures as having an 'unmodified' modification

### DIFF
--- a/SourceKitStressTester/Sources/Common/Message.swift
+++ b/SourceKitStressTester/Sources/Common/Message.swift
@@ -78,6 +78,12 @@ public enum RequestInfo {
 public struct DocumentInfo: Codable {
   public let path: String
   public let modification: DocumentModification?
+  /// A String with enough information to unique identify the state of a
+  /// document in comparison to other modifications produced by the stress
+  /// tester.
+  public var modificationSummaryCode: String {
+    return modification?.summaryCode ?? "unmodified"
+  }
 
   public init(path: String, modification: DocumentModification? = nil) {
     self.path = path
@@ -92,6 +98,13 @@ public struct DocumentModification: Codable {
   public init(mode: RewriteMode, content: String) {
     self.mode = mode
     self.content = content
+  }
+
+  /// A String with enough information to unique identify the modified state of
+  /// a document in comparison to other modifications produced by the stress
+  /// tester.
+  public var summaryCode: String {
+    return "\(mode)-\(content.count)"
   }
 }
 

--- a/SourceKitStressTester/Sources/SwiftCWrapper/ExpectedIssue.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/ExpectedIssue.swift
@@ -48,7 +48,7 @@ public struct ExpectedIssue: Equatable, Codable {
   private func matches(_ info: RequestInfo) -> Bool {
     func matchDocument(_ doc: DocumentInfo) -> Bool {
       return match(doc.path, against: path) &&
-        match(doc.modification?.summaryCode, against: modification)
+        match(doc.modificationSummaryCode, against: modification)
     }
 
     switch info {
@@ -163,55 +163,55 @@ public extension ExpectedIssue {
       switch failure.request {
       case .editorOpen(let document):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .editorOpen
       case .editorClose(let document):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .editorClose
       case .editorReplaceText(let document, let offset, let length, let text):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .editorReplaceText(offset: offset, length: length, text: text)
       case .cursorInfo(let document, let offset, _):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .cursorInfo(offset: offset)
       case .format(let document, let offset):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .format(offset: offset)
       case .codeComplete(let document, let offset, _):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .codeComplete(offset: offset)
       case .rangeInfo(let document, let offset, let length, _):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .rangeInfo(offset: offset, length: length)
       case .semanticRefactoring(let document, let offset, let refactoring, _):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .semanticRefactoring(offset: offset, refactoring: refactoring)
       case .typeContextInfo(let document, let offset, _):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .typeContextInfo(offset: offset)
       case .conformingMethodList(let document, let offset, _, _):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .conformingMethodList(offset: offset)
       case .collectExpressionType(let document, _):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .collectExpressionType
       case .writeModule(let document, _):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .writeModule
       case .interfaceGen(let document, _, _):
         path = document.path
-        modification = document.modification?.summaryCode
+        modification = document.modificationSummaryCode
         issueDetail = .interfaceGen
       case .statistics:
         path = "<statistics>"

--- a/SourceKitStressTester/Sources/SwiftCWrapper/IssueManager.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/IssueManager.swift
@@ -112,15 +112,6 @@ fileprivate struct IssueManagerState: Codable {
   var unmatchedExpectedIssues = [ExpectedIssue]()
 }
 
-extension DocumentModification {
-  /// A String with enough information to unique identify the modified state of
-  /// a document in comparison to other modifications produced by the stress
-  /// tester.
-  var summaryCode: String {
-    return "\(mode)-\(content.count)"
-  }
-}
-
 extension StressTesterIssue: Codable {
   private enum CodingKeys: String, CodingKey {
     case kind, sourceKitError, status, file, arguments

--- a/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
+++ b/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
@@ -173,13 +173,13 @@ class SwiftCWrapperToolTests: XCTestCase {
   func testIssueManager() {
     let xfail = ExpectedIssue(
       applicableConfigs: ["main"], issueUrl: "<issue-url>",
-      path: "*/foo/bar.swift", modification: nil,
+      path: "*/foo/bar.swift", modification: "unmodified",
       issueDetail: .editorReplaceText(offset: 42, length: 0, text: nil)
     )
 
     let xfail2 = ExpectedIssue(
       applicableConfigs: ["main"], issueUrl: "<issue-url",
-      path: "*/foo/bar.swift", modification: nil,
+      path: "*/foo/bar.swift", modification: "unmodified",
       issueDetail: .stressTesterCrash(status: 2, arguments: "*concurrent*"))
 
     let document1 = DocumentInfo(path: "/baz/foo/bar.swift", modification: nil)


### PR DESCRIPTION
Previously, no modification was represented by a missing 'modification' entry in the XFails file. But our internal modification logic matched that to any modification, which might be totally unrelated.