### PR TITLE
Add a soft timeout if a request’s duration is close to the timeout

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
@@ -172,15 +172,19 @@ public struct StressTesterTool: ParsableCommand {
         let errors = tester.run(swiftc: swiftc!, compilerArgs: processedArgs)
 
         if !errors.isEmpty {
+          var hasOnlySoftErrors = true
           for error in errors {
             if let error = error as? SourceKitError {
+              hasOnlySoftErrors = hasOnlySoftErrors && error.isSoft
               let message = StressTesterMessage.detected(error)
               try StressTesterTool.report(message, as: format)
             } else {
               throw error
             }
           }
-          throw ExitCode.failure
+          if !hasOnlySoftErrors {
+            throw ExitCode.failure
+          }
         }
 
         // Leave for debugging purposes if there was an error

--- a/SourceKitStressTester/Sources/SwiftCWrapper/IssueManager.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/IssueManager.swift
@@ -62,7 +62,7 @@ public struct IssueManager {
           state.expectedIssueMessages[match.issueUrl, default: []].append(String(describing: issue))
           state.unmatchedExpectedIssues.removeAll(where: {$0 == match})
           matchingSpec = match
-        } else {
+        } else if !issue.isSoftError {
           let xfail = ExpectedIssue(matching: issue, issueUrl: "<issue url>",
                                     config: activeConfig)
           let json = try encoder.encode(xfail)

--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -300,4 +300,14 @@ public enum StressTesterIssue: CustomStringConvertible {
         """
     }
   }
+
+  /// Returns `true`if this issue represents a soft `SourceKitError`.
+  public var isSoftError: Bool {
+    switch self {
+    case .failed(sourceKitError: let sourceKitError, arguments: _):
+      return sourceKitError.isSoft
+    case .errored:
+      return false
+    }
+  }
 }


### PR DESCRIPTION
Requests that time out are flaky if their duration is close to the timeout level, because they will sometimes finish within the allowed time and sometimes fail. This is especially true if the machine is under heavy load, which is common when stress testing a project.

To mitigate some of this flakiness, introduce soft errors: Whenever a requests takes more than half of the allowed time, throw a soft error. This error will match an XFail, but will not fail the stress tester on its own.

So the idea is to have all of the potential timeout cases in the XFails file. We will only be required to remove it from there, if its execution duration has improved significantly (by more than 2x).