### PR TITLE
Reduce SourceKit timeout to 60 seconds

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -15,7 +15,7 @@ import SwiftSyntax
 import Common
 import Foundation
 
-let SOURCEKIT_REQUEST_TIMEOUT = 300 // seconds
+let SOURCEKIT_REQUEST_TIMEOUT = 60 // seconds
 
 class SourceKitDocument {
   let swiftc: String


### PR DESCRIPTION
From my offline calculations, this should reduce the time it takes to stress test the source compatibility suite by ~2 hours, producing ~50 new XFails due to new timeouts.