### PR TITLE
Adopt split of SwiftSyntaxParser into its own module

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
     ),
     .target(
       name: "StressTester",
-      dependencies: ["Common", "ArgumentParser", "SwiftSyntax", "SwiftSourceKit", "SwiftToolsSupport-auto"],
+      dependencies: ["Common", "ArgumentParser", "SwiftSyntax", "SwiftSyntaxParser", "SwiftSourceKit", "SwiftToolsSupport-auto"],
       swiftSettings: [.unsafeFlags(["-Fsystem", sourcekitSearchPath])],
       linkerSettings: [.unsafeFlags(["-Xlinker", "-F", "-Xlinker", sourcekitSearchPath])]
     ),

--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 import SwiftSyntax
+import SwiftSyntaxParser
 
 public protocol ActionGenerator {
   func generate(for tree: SourceFileSyntax) -> [Action]

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -12,6 +12,7 @@
 
 import SwiftSourceKit
 import SwiftSyntax
+import SwiftSyntaxParser
 import Common
 import Foundation
 

--- a/SwiftEvolve/Package.swift
+++ b/SwiftEvolve/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         ),
         .target(
             name: "SwiftEvolve",
-            dependencies: ["SwiftToolsSupport-auto", "SwiftSyntax"],
+            dependencies: ["SwiftToolsSupport-auto", "SwiftSyntax", "SwiftSyntaxParser"],
             linkerSettings: [.unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", sourcekitSearchPath])]
         ),
         .testTarget(

--- a/SwiftEvolve/Sources/SwiftEvolve/SwiftEvolveTool.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SwiftEvolveTool.swift
@@ -16,6 +16,7 @@
 
 import Foundation
 import SwiftSyntax
+import SwiftSyntaxParser
 import TSCBasic
 
 public class SwiftEvolveTool {

--- a/SwiftEvolve/Tests/SwiftEvolveTests/RegressionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/RegressionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SwiftSyntax
+import SwiftSyntaxParser
 import SwiftEvolve
 
 class RegressionTests: XCTestCase {

--- a/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleGenericRequirementsEvolutionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleGenericRequirementsEvolutionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SwiftSyntax
+import SwiftSyntaxParser
 import SwiftEvolve
 
 class ShuffleGenericRequirementsEvolutionTests: XCTestCase {

--- a/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleMembersEvolutionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleMembersEvolutionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SwiftSyntax
+import SwiftSyntaxParser
 import SwiftEvolve
 
 class ShuffleMembersEvolutionTests: XCTestCase {


### PR DESCRIPTION
Companion to https://github.com/apple/swift-syntax/pull/309

Adopt the breaking SwiftSyntax API change that moves SwiftSyntaxParser into its own module.