### PR TITLE
Make the stress tester only link to SwiftSyntaxParser, not SwiftSyntax

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
     ),
     .target(
       name: "StressTester",
-      dependencies: ["Common", "ArgumentParser", "SwiftSyntax", "SwiftSyntaxParser", "SwiftSourceKit", "SwiftToolsSupport-auto"],
+      dependencies: ["Common", "ArgumentParser", "SwiftSyntaxParser", "SwiftSourceKit", "SwiftToolsSupport-auto"],
       swiftSettings: [.unsafeFlags(["-Fsystem", sourcekitSearchPath])],
       linkerSettings: [.unsafeFlags(["-Xlinker", "-F", "-Xlinker", sourcekitSearchPath])]
     ),

--- a/SwiftEvolve/Package.swift
+++ b/SwiftEvolve/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         ),
         .target(
             name: "SwiftEvolve",
-            dependencies: ["SwiftToolsSupport-auto", "SwiftSyntax", "SwiftSyntaxParser"],
+            dependencies: ["SwiftToolsSupport-auto", "SwiftSyntaxParser"],
             linkerSettings: [.unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", sourcekitSearchPath])]
         ),
         .testTarget(


### PR DESCRIPTION
`SwiftSyntaxParser` re-exports the symbols of `SwiftSyntax`, so if the stress tester links to both on both `SwiftSyntaxParser` and `SwiftSyntax` as dylibs, we get warnings about symbols being found twice.

Because `SwiftSyntaxParser` re-exports `SwiftSyntax`, it should be sufficient to only link against `SwiftSyntaxParser`.