### PR TITLE
Use IncremenatalParseTransition initializer taking ConcurrentEdits

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -394,7 +394,7 @@ public final class InsideOutRewriteActionGenerator: ActionGenerator {
   }
 
   private func getPlacedStart(of token: TokenSyntax, in groups: [ActionTokenGroup]) -> AbsolutePosition? {
-    guard let groupIndex = groups.firstIndex(where: { $0.actionTokens.contains { $0.token == token } }) else {
+    guard let groupIndex = groups.firstIndex(where: { $0.actionTokens.contains(where: { $0.token == token }) }) else {
       preconditionFailure("token is contained in provided groups")
     }
     let group = groups[groupIndex]

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -528,8 +528,8 @@ class SourceKitDocument {
     let reparseTransition: IncrementalParseTransition?
     switch request {
     case .editorReplaceText(_, let offset, let length, let text):
-      let edits = [SourceEdit(range: ByteSourceRange(offset: offset, length: length), replacementLength: text.utf8.count)]
-      reparseTransition = IncrementalParseTransition(previousTree: self.tree!, edits: edits)
+      let edit = SourceEdit(range: ByteSourceRange(offset: offset, length: length), replacementLength: text.utf8.count)
+      reparseTransition = IncrementalParseTransition(previousTree: self.tree!, edits: ConcurrentEdits(edit))
     default:
       reparseTransition = nil
     }


### PR DESCRIPTION
The initializer that takes raw edits has been deprecated by https://github.com/apple/swift-syntax/pull/301.