### PR TITLE
Report whether an AST was reused in timing measurements

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/RequestDurationManager.swift
+++ b/SourceKitStressTester/Sources/StressTester/RequestDurationManager.swift
@@ -47,6 +47,10 @@ struct Timing: Codable {
 
   /// The number of instructions sourcekitd took to exeucte the request.
   var instructions: Int
+
+  /// Whether SourceKit reused an AST when serving the request. `nil` if it is
+  /// unknown whether an AST was reused.
+  var reusingASTContext: Bool?
 }
 
 /// Captures aggregated information about executing a certain request kind on a

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -226,7 +226,7 @@ class SourceKitDocument {
     return 0
   }
 
-  func codeComplete(offset: Int, expectedResult: ExpectedResult?) throws -> (request: RequestInfo, response: SourceKitdResponse, instructions: Int) {
+  func codeComplete(offset: Int, expectedResult: ExpectedResult?) throws -> (request: RequestInfo, response: SourceKitdResponse, instructions: Int, reusingASTContext: Bool) {
     let request = SourceKitdRequest(uid: .request_CodeComplete)
 
     request.addParameter(.key_SourceFile, value: args.forFile.path)
@@ -243,8 +243,9 @@ class SourceKitDocument {
         try checkExpectedCompletionResult(expectedResult, in: response, info: info)
       }
     }
+    let reusingASTContext = response.value.getBool(.key_ReusingASTContext)
 
-    return (info, response, instructions)
+    return (info, response, instructions, reusingASTContext)
   }
 
   func typeContextInfo(offset: Int) throws -> (RequestInfo, SourceKitdResponse) {

--- a/SourceKitStressTester/Sources/SwiftSourceKit/UIDs.swift
+++ b/SourceKitStressTester/Sources/SwiftSourceKit/UIDs.swift
@@ -166,6 +166,7 @@ extension SourceKitdUID {
   public static let key_ExpressionLength = SourceKitdUID(string: "key.expression_length")
   public static let key_ExpressionType = SourceKitdUID(string: "key.expression_type")
   public static let key_RetrieveSymbolGraph = SourceKitdUID(string: "key.retrieve_symbol_graph")
+  public static let key_ReusingASTContext = SourceKitdUID(string: "key.reusingastcontext")
 
   public static let request_ProtocolVersion = SourceKitdUID(string: "source.request.protocol_version")
   public static let request_CompilerVersion = SourceKitdUID(string: "source.request.compiler_version")


### PR DESCRIPTION
This will allow us to analyse the performance of fast completion (which is reusing an AST context) vs. normal completion that’s not reusing an AST context.