### PR TITLE
Support SwiftNames without a closing parenthesis

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/Action.swift
+++ b/SourceKitStressTester/Sources/StressTester/Action.swift
@@ -153,7 +153,7 @@ public struct SwiftName: Codable, Hashable {
 
   public init?(_ name: String) {
     if let argStart = name.firstIndex(of: "(") {
-      guard let argEnd = name.firstIndex(of: ")") else { return nil }
+      let argEnd = name.firstIndex(of: ")") ?? name.endIndex
       base = String(name[..<argStart])
       argLabels = name[name.index(after: argStart)..<argEnd]
         .split(separator: ":", omittingEmptySubsequences: false)


### PR DESCRIPTION
The new `codecomplete.open` API sometimes returns code completion results that have an open but no closing parenthesis (e.g. `Color(`). Make sure we create a valid `SwiftName` for those results so we don’t crash.