### PR TITLE
Add support for a Package-config.json to specify defaults for environment variables

### DIFF
--- a/SourceKitStressTester/.gitignore
+++ b/SourceKitStressTester/.gitignore
@@ -6,3 +6,4 @@
 /DerivedData
 /Package.resolved
 /.swiftpm
+/Package-config.json


### PR DESCRIPTION
When opening the project in Xcode, I always needed to edit the package manifest to point to the correct SourceKit search path, undo the changes to rebase etc. That's annoying.

Allow the a `Package-config.json` next to the `Package.swift` file, which is consulted for default values for the environment variables (environment variables still take precedence). That config file is in `.gitignore`, so it can persist between git operations.