### PR TITLE
Disable testable imports

### DIFF
--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -190,7 +190,7 @@ def invoke_swift_single_product(package_dir, swift_exec, action, product, build_
     args.extend(['--multiroot-data-file', multiroot_data_file])
 
   if action == 'test':
-    args.extend(['--test-product', product])
+    args.extend(['--test-product', product, '--disable-testable-imports'])
   else:
     args.extend(['--product', product])
 


### PR DESCRIPTION
Testable imports might be the reason why running the swift stress tester tests takes ~4 minutes. We don’t need them, so disable them.

rdar://88676307