### PR TITLE
Increase minimum macOS version for swift-evolve to match TSC

### DIFF
--- a/SwiftEvolve/Package.swift
+++ b/SwiftEvolve/Package.swift
@@ -22,6 +22,9 @@ if let sourcekitSearchPathPointer = getenv("SWIFT_STRESS_TESTER_SOURCEKIT_SEARCH
 
 let package = Package(
     name: "SwiftEvolve",
+    platforms: [
+      .macOS(.v10_13),
+    ],
     products: [
         .executable(name: "swift-evolve", targets: ["swift-evolve"]),
         .library(name: "SwiftEvolve", targets: ["SwiftEvolve"])


### PR DESCRIPTION
swift-tools-support-core (which swift-evolve depends on) raised its minimum macOS version to 10.13 in https://github.com/apple/swift-tools-support-core/pull/329.