### PR TITLE
Stop using the old syntax builder

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
@@ -335,9 +335,10 @@ extension SynthesizeMemberwiseInitializerEvolution {
         body: body
       )
       
-      return members.appending(MemberDeclListItemSyntax {
-        $0.useDecl(DeclSyntax(newInitializer))
-      })
+      return members.appending(SyntaxFactory.makeMemberDeclListItem(
+        decl: DeclSyntax(newInitializer),
+        semicolon: nil
+      ))
     }
     return Syntax(evolved)
   }


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/568.

---

Switch to use the `SyntaxFactory` for now before we deprecate that in favor of initializers/static methods on the syntax types.