### PR TITLE
Migrate SwiftEvolve from SyntaxFactory to initializers

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
@@ -306,7 +306,7 @@ extension PatternSyntax {
       return []
 
     default:
-      return [(SyntaxFactory.makeUnknown("<unknown>"), nil)]
+      return [(TokenSyntax.unknown("<unknown>"), nil)]
     }
   }
 }

--- a/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
@@ -197,7 +197,7 @@ extension ShuffleMembersEvolution {
     let missing = members.indices.filter { !inMapping.contains($0) }
     let fullMapping = mapping + missing
 
-    return Syntax(SyntaxFactory.makeMemberDeclList(fullMapping.map { members[$0] }))
+    return Syntax(MemberDeclListSyntax(fullMapping.map { members[$0] }))
   }
 }
 
@@ -292,12 +292,12 @@ extension SynthesizeMemberwiseInitializerEvolution {
     
     let evolved = inits.reduce(members) { members, properties in
       let parameters = properties.mapToFunctionParameterClause {
-        SyntaxFactory.makeFunctionParameter(
+        FunctionParameterSyntax(
           attributes: nil,
-          firstName: SyntaxFactory.makeIdentifier($0.name),
+          firstName: .identifier($0.name),
           secondName: nil,
-          colon: SyntaxFactory.makeColonToken(trailingTrivia: [.spaces(1)]),
-          type: SyntaxFactory.makeTypeIdentifier($0.type),
+          colon: .colonToken(trailingTrivia: [.spaces(1)]),
+          type: TypeSyntax(SimpleTypeIdentifierSyntax(name: .identifier($0.type), genericArgumentClause: nil)),
           ellipsis: nil,
           defaultArgument: nil,
           trailingComma: nil
@@ -311,16 +311,16 @@ extension SynthesizeMemberwiseInitializerEvolution {
         return Syntax(expr)
       }
 
-      let signature = SyntaxFactory.makeFunctionSignature(
+      let signature = FunctionSignatureSyntax(
         input: parameters,
         asyncOrReasyncKeyword: nil,
         throwsOrRethrowsKeyword: nil,
         output: nil)
 
-      let newInitializer = SyntaxFactory.makeInitializerDecl(
+      let newInitializer = InitializerDeclSyntax(
         attributes: nil,
         modifiers: nil,
-        initKeyword: SyntaxFactory.makeInitKeyword(
+        initKeyword: .initKeyword(
           leadingTrivia: [
             .newlines(2),
             .lineComment("// Synthesized by SynthesizeMemberwiseInitializerEvolution"),
@@ -335,7 +335,7 @@ extension SynthesizeMemberwiseInitializerEvolution {
         body: body
       )
       
-      return members.appending(SyntaxFactory.makeMemberDeclListItem(
+      return members.appending(MemberDeclListItemSyntax(
         decl: DeclSyntax(newInitializer),
         semicolon: nil
       ))
@@ -368,7 +368,7 @@ extension ShuffleGenericRequirementsEvolution {
     precondition(requirements.count == mapping.count,
                  "ShuffleGenericRequirementsEvolution mapping does not match node it's being applied to")
 
-    let genericRequirements = SyntaxFactory.makeGenericRequirementList(
+    let genericRequirements = GenericRequirementListSyntax(
       mapping.map { requirements[$0] }.withCorrectTrailingCommas()
     )
     return Syntax(genericRequirements)

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
@@ -28,7 +28,7 @@ extension BidirectionalCollection where Element: TrailingCommaSyntax {
     var elems: [Element] = []
 
     for elem in dropLast() {
-      let newComma = SyntaxFactory.makeCommaToken(trailingTrivia: betweenTrivia)
+      let newComma = TokenSyntax.commaToken(trailingTrivia: betweenTrivia)
       let newElem = elem.withTrailingComma(newComma)
       elems.append(newElem)
     }
@@ -52,12 +52,12 @@ extension Collection {
     let params = try map(transform)
       .withCorrectTrailingCommas(betweenTrivia: betweenTrivia)
 
-    return SyntaxFactory.makeParameterClause(
-      leftParen: SyntaxFactory.makeLeftParenToken(
+    return ParameterClauseSyntax(
+      leftParen: .leftParenToken(
         leadingTrivia: outerLeadingTrivia, trailingTrivia: innerLeadingTrivia
       ),
-      parameterList: SyntaxFactory.makeFunctionParameterList(params),
-      rightParen: SyntaxFactory.makeRightParenToken(
+      parameterList: FunctionParameterListSyntax(params),
+      rightParen: .rightParenToken(
         leadingTrivia: innerTrailingTrivia, trailingTrivia: outerTrailingTrivia
       )
     )
@@ -73,7 +73,7 @@ extension Collection {
     _ transform: (Element) throws -> Syntax
   ) rethrows -> CodeBlockSyntax {
     let stmts = try map {
-      SyntaxFactory.makeCodeBlockItem(
+      CodeBlockItemSyntax(
         item: try transform($0).replacingTriviaWith(
           leading: statementLeadingTrivia, trailing: statementTrailingTrivia
         ),
@@ -82,12 +82,12 @@ extension Collection {
       )
     }
     
-    return SyntaxFactory.makeCodeBlock(
-      leftBrace: SyntaxFactory.makeLeftBraceToken(
+    return CodeBlockSyntax(
+      leftBrace: .leftBraceToken(
         leadingTrivia: outerLeadingTrivia, trailingTrivia: innerLeadingTrivia
       ),
-      statements: SyntaxFactory.makeCodeBlockItemList(stmts),
-      rightBrace: SyntaxFactory.makeRightBraceToken(
+      statements: CodeBlockItemListSyntax(stmts),
+      rightBrace: .rightBraceToken(
         leadingTrivia: innerTrailingTrivia, trailingTrivia: outerTrailingTrivia
       )
     )
@@ -117,11 +117,11 @@ struct ExprSyntaxTemplate {
     guard case .identifier(_) = identifier.tokenKind else {
       preconditionFailure("ExprSyntaxTemplate(var:) called with non-identifier \(identifier)")
     }
-    self.init(expr: ExprSyntax(SyntaxFactory.makeIdentifierExpr(identifier: identifier, declNameArguments: nil)))
+    self.init(expr: ExprSyntax(IdentifierExprSyntax(identifier: identifier, declNameArguments: nil)))
   }
   
   init(_ name: String) {
-    self.init(SyntaxFactory.makeIdentifier(name))
+    self.init(.identifier(name))
   }
   
   static var _self: ExprSyntaxTemplate {
@@ -133,25 +133,25 @@ struct ExprSyntaxTemplate {
   static func ^= (
     lhs: ExprSyntaxTemplate, rhs: ExprSyntaxTemplate
   ) -> ExprSyntaxTemplate {
-    let assignment = SyntaxFactory.makeAssignmentExpr(
-      assignToken: SyntaxFactory.makeEqualToken(
+    let assignment = AssignmentExprSyntax(
+      assignToken: .equalToken(
         leadingTrivia: .spaces(1), trailingTrivia: .spaces(1)
       )
     )
-    let exprList = SyntaxFactory.makeExprList([
+    let exprList = ExprListSyntax([
       lhs.expr,
       ExprSyntax(assignment),
       rhs.expr
     ])
     return ExprSyntaxTemplate(
-      expr: ExprSyntax(SyntaxFactory.makeSequenceExpr(elements: exprList))
+      expr: ExprSyntax(SequenceExprSyntax(elements: exprList))
     )
   }
   
   subscript (dot identifier: TokenSyntax) -> ExprSyntaxTemplate {
-    let memberAccess = SyntaxFactory.makeMemberAccessExpr(
+    let memberAccess = MemberAccessExprSyntax(
       base: expr,
-      dot: SyntaxFactory.makePeriodToken(),
+      dot: .periodToken(),
       name: identifier,
       declNameArguments: nil
     )
@@ -159,7 +159,7 @@ struct ExprSyntaxTemplate {
   }
   
   subscript (dot name: String) -> ExprSyntaxTemplate {
-    return self[dot: SyntaxFactory.makeIdentifier(name)]
+    return self[dot: .identifier(name)]
   }
   
   subscript (dynamicMember name: String) -> ExprSyntaxTemplate {

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -114,21 +114,21 @@ func != (lhs: Syntax?, rhs: Syntax?) -> Bool {
 
 extension DeclContext {
   var typeSyntax: TypeSyntax {
-    let name = SyntaxFactory.makeIdentifier(last!.name)
+    let name = TokenSyntax.identifier(last!.name)
     let parent = removingLast()
     
     if parent.declarationChain.allSatisfy({ $0 is SourceFileSyntax }) {
       // Base case
-      let typeIdentifier = SyntaxFactory.makeSimpleTypeIdentifier(
+      let typeIdentifier = SimpleTypeIdentifierSyntax(
         name: name,
         genericArgumentClause: nil
       )
       return TypeSyntax(typeIdentifier)
     }
     
-    let typeIdentifer = SyntaxFactory.makeMemberTypeIdentifier(
+    let typeIdentifer = MemberTypeIdentifierSyntax(
       baseType: parent.typeSyntax,
-      period: SyntaxFactory.makePeriodToken(),
+      period: .periodToken(),
       name: name,
       genericArgumentClause: nil
     )


### PR DESCRIPTION
`SyntaxFactory` has been deprecated.