### PR TITLE
Reduce soft timeout to 1/5 of the normal timeout

### DIFF
--- a/SourceKitStressTester/Sources/Common/Message.swift
+++ b/SourceKitStressTester/Sources/Common/Message.swift
@@ -516,7 +516,7 @@ extension SourceKitError: CustomStringConvertible {
         """
     case .softTimeout(let request, let duration, let instructions):
       return """
-        Request took \(duration) seconds (\(instructions.map(String.init) ?? "<unknown>") instructions) to execute. This is more than half of the allowed time. This error will match XFails but won't count as an error by itself.
+        Request took \(duration) seconds (\(instructions.map(String.init) ?? "<unknown>") instructions) to execute. This is more than a fifth of the allowed time. This error will match XFails but won't count as an error by itself.
           request: \(request)
         -- begin file content --------
         \(markSourceLocation(of: request) ?? "<unmodified>")

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -520,7 +520,7 @@ class SourceKitDocument {
         try throwIfInvalid(response, request: info)
         try validateResponse(response)
 
-        if requestDuration > TimeInterval(SOURCEKIT_REQUEST_TIMEOUT) / 2 {
+        if requestDuration > TimeInterval(SOURCEKIT_REQUEST_TIMEOUT) / 5 {
           // There was no error in the response, but the request took too long
           // throw a soft timeout.
           throw SourceKitError.softTimeout(request: info, duration: requestDuration, instructions: nil)


### PR DESCRIPTION
We saw a few flaky timeouts when running the stress tester, where sometimes a request would finish in <2.5 minutes but sometimes took more than 5. Issue a soft timeout failure that can match the XFail if a request took more than 1 minute to execute. This should hopefully reduce the flakiness.