### PR TITLE
Use the new parser for stress-testing

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -51,7 +51,7 @@ func getConfigParam(_ name: String) -> String? {
 /// The environment variable is only specified once we build the stress tester.
 let sourceKitSearchPath: String? = getConfigParam("SWIFT_STRESS_TESTER_SOURCEKIT_SEARCHPATH")
 
-/// Path to a directory containing SwiftSyntax.framework and SwiftSyntaxParser.framework.
+/// Path to a directory containing SwiftSyntax.framework and SwiftParser.framework.
 /// Optional. If not specified, SwiftSyntax will be built from source.
 let swiftSyntaxSearchPath: String? = getConfigParam("SWIFT_STRESS_TESTER_SWIFTSYNTAX_SEARCHPATH")
 
@@ -91,7 +91,7 @@ if let swiftSyntaxSearchPath = swiftSyntaxSearchPath {
 } else {
   stressTesterTargetDependencies += [
     .product(name: "SwiftSyntax", package: "swift-syntax"),
-    .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
+    .product(name: "SwiftParser", package: "swift-syntax"),
   ]
 }
 
@@ -165,7 +165,7 @@ if !useLocalDependencies {
   // Building standalone.
   package.dependencies += [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.4.3")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
   ]
   if swiftSyntaxSearchPath == nil {
     package.dependencies.append(.package(url: "https://github.com/apple/swift-syntax.git", .branch("main")))

--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import SwiftParser
 import SwiftSyntax
-import SwiftSyntaxParser
 
 public protocol ActionGenerator {
   func generate(for tree: SourceFileSyntax) -> [Action]
@@ -21,13 +21,16 @@ public protocol ActionGenerator {
 extension ActionGenerator {
   /// Entrypoint intended for testing purposes only
   public func generate(for file: URL) -> [Action] {
-    let tree = try! SyntaxParser.parse(file)
-    return generate(for: tree)
+    let fileData = try! Data(contentsOf: file)
+    let source = fileData.withUnsafeBytes { buf in
+      return String(decoding: buf.bindMemory(to: UInt8.self), as: UTF8.self)
+    }
+    return generate(for: source)
   }
 
   /// Entrypoint intended for testing purposes only
   public func generate(for source: String) -> [Action] {
-    let tree = try! SyntaxParser.parse(source: source)
+    let tree = try! Parser.parse(source: source)
     return generate(for: tree)
   }
 

--- a/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
@@ -62,42 +62,43 @@ class ActionGeneratorTests: XCTestCase {
   }
 
   func testCompletionExpectedResults() {
-    typealias TestCase = (source: String, expected: [String])
+    typealias TestCase = (line: UInt, source: String, expected: [String])
     let cases: [TestCase] = [
-      ("foo(x: 10)", ["call:foo(x:)"]),
-      ("foo(45)", ["call:foo(_:)"]),
-      ("foo.bar(first, x: 10)", ["foo", "call:bar(_:x:)", "first", "x:"]),
-      ("foo.bar(x:_:)", ["foo", "bar(x:_:)"]),
+      (#line, "foo(x: 10)", ["call:foo(x:)"]),
+      (#line, "foo(45)", ["call:foo(_:)"]),
+      (#line, "foo.bar(first, x: 10)", ["foo", "call:bar(_:x:)", "first", "x:"]),
+      (#line, "foo.bar(x:_:)", ["foo", "bar(x:_:)"]),
 
       // FIXME: code completion doesn't complete compound name references
-      (".foo(x:y:z:)", ["foo(x:y:z:)"/*, "x", "y", "z"*/]),
-      (".foo(1, 2, other: 5)", ["call:foo(_:_:other:)", "other:"]),
-      ("Foo.foo(fooInstance)(x: 10)", ["Foo", "call:foo(x:)", "fooInstance"]),
+      (#line, ".foo(x:y:z:)", ["foo(x:y:z:)"/*, "x", "y", "z"*/]),
+      (#line, ".foo(1, 2, other: 5)", ["call:foo(_:_:other:)", "other:"]),
+      (#line, "Foo.foo(fooInstance)(x: 10)", ["Foo", "call:foo(x:)", "fooInstance"]),
 
       // The below foo could be either foo(_:) or foo(_:_:), we can't tell
       // syntactically so default to the outer argument list, as it will match
       // even if it should have been the inner argument list due to the
       // incomplete information the matching logic has (it has to assume any
       // parameter could be defaulted or variadic).
-      ("Foo.foo(fooInstance)(10, 20)", ["Foo", "call:foo(_:_:)", "fooInstance"]),
-      ("Foo.foo(fooInstance)()", ["Foo", "call:foo", "fooInstance"]),
-      ("let (x, y) = (a, b)", ["a", "b"]),
-      ("if case let .myCase(Int.max, second) = p {}", ["patt:myCase(_:_:)", "Int", "max", "p"]),
-      ("if case let .myCase(.inner(x:foo), second) = p {}", ["patt:myCase(_:_:)", "patt:inner(x:)", "p"]),
-      ("switch x { case .some(2?): break }", ["x", "patt:some(_:)"]),
+      (#line, "Foo.foo(fooInstance)(10, 20)", ["Foo", "call:foo(_:_:)", "fooInstance"]),
+      (#line, "Foo.foo(fooInstance)()", ["Foo", "call:foo", "fooInstance"]),
+      (#line, "let (x, y) = (a, b)", ["a", "b"]),
+      (#line, "if case let .myCase(Int.max, second) = p {}", ["patt:myCase(_:_:)", "Int", "max", "p"]),
+      (#line, "if case let .myCase(.inner(x:foo), second) = p {}", ["patt:myCase(_:_:)", "patt:inner(x:)", "p"]),
+      (#line, "switch x { case .some(2?): break }", ["x", "patt:some(_:)"]),
 
       // TODO: we don't check operators at the moment
-      ("3 + 4", []),
+      (#line, "3 + 4", []),
       // FIXME: code completion doesn't offer labels after break/continue
-      ("foo: for x in 1...4 { print(x); break foo }", ["call:print(_:)", "x"/*, "foo"*/]),
+      (#line, "foo: for x in 1...4 { print(x); break foo }", ["call:print(_:)", "x"/*, "foo"*/]),
 
       // TODO: subscript completions after [
-      ("data[position]", ["data", "position"]),
-      ("data[position, default: 0]", ["data", "position", "default:"]),
+      (#line, "data[position]", ["data", "position"]),
+      // FIXME: `default` should also be an action position: https://github.com/apple/swift-syntax/issues/829
+      (#line, "data[position, default: 0]", ["data", "position"]),
 
       // FIXME: completion doesn't suggest anonymous closure params (e.g. $0)
-      ("$0.first", [/*"$0",*/ "first"]),
-      ("[1,2,4].filter{ $0 == 4 }", ["call:filter"/*, "$0"*/])
+      (#line, "$0.first", [/*"$0",*/ "first"]),
+      (#line, "[1,2,4].filter{ $0 == 4 }", ["call:filter"/*, "$0"*/])
     ]
 
     for test in cases {
@@ -117,7 +118,7 @@ class ActionGeneratorTests: XCTestCase {
           }
           return nil
         }
-      XCTAssertEqual(generated, test.expected)
+      XCTAssertEqual(generated, test.expected, line: test.line)
     }
   }
 


### PR DESCRIPTION
Running the stress tester found one new SourceKit crash that I still need to reduce: https://ci.swift.org/job/swift-PR-macos-with-sourcekit-stress-tester/150/console

Otherwise, everything appears to be passing.