### PR TITLE
Fold operators after parsing

### DIFF
--- a/SourceKitStressTester/Package.swift
+++ b/SourceKitStressTester/Package.swift
@@ -92,6 +92,7 @@ if let swiftSyntaxSearchPath = swiftSyntaxSearchPath {
   stressTesterTargetDependencies += [
     .product(name: "SwiftSyntax", package: "swift-syntax"),
     .product(name: "SwiftParser", package: "swift-syntax"),
+    .product(name: "SwiftOperators", package: "swift-syntax"),
   ]
 }
 

--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -13,6 +13,7 @@
 import Foundation
 import SwiftParser
 import SwiftSyntax
+import SwiftOperators
 
 public protocol ActionGenerator {
   func generate(for tree: SourceFileSyntax) -> [Action]
@@ -30,7 +31,10 @@ extension ActionGenerator {
 
   /// Entrypoint intended for testing purposes only
   public func generate(for source: String) -> [Action] {
-    let tree = try! Parser.parse(source: source)
+    var tree = try! Parser.parse(source: source)
+    if let foldedTree = try? OperatorTable.standardOperators.foldAll(tree).as(SourceFileSyntax.self) {
+      tree = foldedTree
+    }
     return generate(for: tree)
   }
 

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -14,6 +14,7 @@ import SwiftSourceKit
 import SwiftDiagnostics
 import SwiftParser
 import SwiftSyntax
+import SwiftOperators
 import Common
 import Foundation
 
@@ -580,7 +581,7 @@ class SourceKitDocument {
       reparseTransition = nil
     }
 
-    let tree: SourceFileSyntax
+    var tree: SourceFileSyntax
     if let state = sourceState {
       tree = try Parser.parse(
         source: state.source,
@@ -592,6 +593,9 @@ class SourceKitDocument {
         return String(decoding: buf.bindMemory(to: UInt8.self), as: UTF8.self)
       }
       tree = try Parser.parse(source: source)
+    }
+    if let foldedTree = OperatorTable.standardOperators.foldAll(tree, errorHandler: { _ in }).as(SourceFileSyntax.self) {
+      tree = foldedTree
     }
     _ = ParseDiagnosticsGenerator.diagnostics(for: tree)
     return tree


### PR DESCRIPTION
The primary use case for this is to stress test SwiftOperators.