### PR TITLE
Update for modelling of `isolated` and `_const` as parameter modifiers

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
@@ -294,8 +294,7 @@ extension SynthesizeMemberwiseInitializerEvolution {
       let parameters = properties.mapToFunctionParameterClause {
         FunctionParameterSyntax(
           attributes: nil,
-          isolatedToken: nil,
-          constToken: nil,
+          modifiers: nil,
           firstName: .identifier($0.name),
           secondName: nil,
           colon: .colonToken(trailingTrivia: [.spaces(1)]),


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/861