### PR TITLE
Print compiler arguments before starting stress testing

### DIFF
--- a/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
+++ b/SourceKitStressTester/Sources/SwiftCWrapper/SwiftCWrapper.swift
@@ -117,6 +117,10 @@ public struct SwiftCWrapper {
 
     guard !operations.isEmpty else { return swiftcResult.status }
 
+    if !suppressOutput {
+      stderrStream <<< "Compiler arguments: \(escapeArgs(arguments))\n"
+    }
+
     // Run the operations, reporting progress
     let progress: ProgressAnimationProtocol?
     if !suppressOutput {


### PR DESCRIPTION
I found this super useful to reproce stress tester failures because that way you don’t need to wait for the stress tester run to finish to get the compiler arguments of a file that’s failing.