### PR TITLE
Declare identifiers in key path property components as references

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/SwiftSyntaxExtensions.swift
+++ b/SourceKitStressTester/Sources/StressTester/SwiftSyntaxExtensions.swift
@@ -79,7 +79,8 @@ extension TokenSyntax {
     guard let parent = parent else { return false }
     return parent.isProtocol(ExprSyntaxProtocol.self) ||
       parent.isProtocol(TypeSyntaxProtocol.self) ||
-      parent.is(TupleExprElementSyntax.self)
+      parent.is(TupleExprElementSyntax.self) ||
+      parent.is(KeyPathPropertyComponentSyntax.self)
   }
 
   var textWithoutBackticks: String {


### PR DESCRIPTION
Adjustment needed to account for https://github.com/apple/swift-syntax/pull/865