### PR TITLE
testStressTesterOperationQueue is flaky, disable for now

### DIFF
--- a/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
+++ b/SourceKitStressTester/Tests/SwiftCWrapperToolTests/SwiftCWrapperToolTests.swift
@@ -76,6 +76,7 @@ class SwiftCWrapperToolTests: XCTestCase {
   }
 
   func testStressTesterOperationQueue() throws {
+    try XCTSkipIf(true, "Failing non-deterministically. Disabling until we have time to investigate - rdar://100970606")
     class TestOperation: Operation {
       var waitCount: Int
 


### PR DESCRIPTION
E.g. https://ci.swift.org/job/swift-syntax-PR-macOS/782/console failed.

testStressTesterOperationQueueis failing non-deterministically in CI. Disabling until we have time to investigate.