### PR TITLE
Raise a softTimeout if the test required more than 1/10 of the timeout duration

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -523,7 +523,7 @@ class SourceKitDocument {
         try throwIfInvalid(response, request: info)
         try validateResponse(response)
 
-        if requestDuration > TimeInterval(SOURCEKIT_REQUEST_TIMEOUT) / 5 {
+        if requestDuration > TimeInterval(SOURCEKIT_REQUEST_TIMEOUT) / 10 {
           // There was no error in the response, but the request took too long
           // throw a soft timeout.
           throw SourceKitError.softTimeout(request: info, duration: requestDuration, instructions: nil)


### PR DESCRIPTION
I hope that this further reduces flakiness we have been seeing.

1/10 of the timeout is still 30s, which is way longer than any request should take.