### PR TITLE
Distinguish open and update code completion request

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -293,7 +293,7 @@ class SourceKitDocument {
       updateOptions["filtertext"] = expectedResult.name.base
 
       let updateRequest = buildCompletionRequest(request: .request_CodeCompleteUpdate, offset: offset, extraOptions: updateOptions)
-      let updateInfo = RequestInfo.codeCompleteOpen(document: documentInfo, offset: offset, args: args.sourcekitdArgs)
+      let updateInfo = RequestInfo.codeCompleteUpdate(document: documentInfo, offset: offset, args: args.sourcekitdArgs)
       let updateResponse = try sendWithTimeout(updateRequest, info: updateInfo) { response in
         try checkExpectedCompletionResult(expectedResult, in: response, info: openInfo)
       }


### PR DESCRIPTION
I’m getting the impression that the insideOut-893 is actually sometimes timing out  during the code completion update. Currently, there’s no way to differentiate the update request from the open request. Handle the two differently to debug the issue.