### PR TITLE
Force ACHNBrowserUI/.../Path.swift insideOut-893:884 to a soft timeout

### DIFF
--- a/SourceKitStressTester/Sources/Common/Message.swift
+++ b/SourceKitStressTester/Sources/Common/Message.swift
@@ -541,7 +541,7 @@ extension SourceKitError: CustomStringConvertible {
         """
     case .softTimeout(let request, let duration, let instructions):
       return """
-        Request took \(duration) seconds (\(instructions.map(String.init) ?? "<unknown>") instructions) to execute. This is more than a fifth of the allowed time. This error will match XFails but won't count as an error by itself.
+        Request took \(duration) seconds (\(instructions.map(String.init) ?? "<unknown>") instructions) to execute. This is more than a tenth of the allowed time. This error will match XFails but won't count as an error by itself.
           request: \(request)
         -- begin file content --------
         \(markSourceLocation(of: request) ?? "<unmodified>")


### PR DESCRIPTION
This request varies wildly between runs. For now just force it to a soft timeout regardless. Also remove the previous attempt at forcing this request to a soft timeout, which seems to not have worked.