### PR TITLE
Don’t filter replacetext actions if an offset filter is passed

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/StressTester.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTester.swift
@@ -150,7 +150,12 @@ public class StressTester {
       .generate(for: tree)
       .filter { action in
         if let offsetFilter = options.offsetFilter, offsetFilter != action.offset {
-          return false
+          if case .replaceText = action {
+            // Don't filter replaceText actions.
+            // They are necessary to reproduce the source state we want to test.
+          } else {
+            return false
+          }
         }
         guard !locationsInvalidated else { return false }
         switch action {


### PR DESCRIPTION
As noted in https://github.com/apple/swift-stress-tester/pull/196#discussion_r1027022494