### PR TITLE
Add an option to print all requests sent to SourceKit as JSON

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/StressTester.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTester.swift
@@ -25,7 +25,7 @@ public class StressTester {
 
   public init(options: StressTesterOptions) {
     self.options = options
-    self.connection = SourceKitdService()
+    self.connection = SourceKitdService(printRequests: options.printRequests)
   }
 
   var generator: ActionGenerator {
@@ -290,6 +290,7 @@ public struct StressTesterOptions {
   public var tempDir: URL
   public var astBuildLimit: Int?
   public var printActions: Bool
+  public var printRequests: Bool
   public var requestDurationsOutputFile: URL?
   public var responseHandler: ((SourceKitResponseData) throws -> Void)?
   public var dryRun: (([Action]) throws -> Void)?
@@ -297,7 +298,7 @@ public struct StressTesterOptions {
   public init(requests: Set<RequestKind>, rewriteMode: RewriteMode,
               conformingMethodsTypeList: [String], page: Page, offsetFilter: Int?,
               tempDir: URL, astBuildLimit: Int? = nil,
-              printActions: Bool = false,
+              printActions: Bool = false, printRequests: Bool = false,
               requestDurationsOutputFile: URL? = nil,
               responseHandler: ((SourceKitResponseData) throws -> Void)? = nil,
               dryRun: (([Action]) throws -> Void)? = nil) {
@@ -309,6 +310,7 @@ public struct StressTesterOptions {
     self.tempDir = tempDir
     self.astBuildLimit = astBuildLimit
     self.printActions = printActions
+    self.printRequests = printRequests
     self.requestDurationsOutputFile = requestDurationsOutputFile
     self.responseHandler = responseHandler
     self.dryRun = dryRun

--- a/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
+++ b/SourceKitStressTester/Sources/StressTester/StressTesterTool.swift
@@ -43,6 +43,11 @@ public struct StressTesterTool: ParsableCommand {
     """)
   public var printActions: Bool = false
 
+  @Flag(name: .long, help: """
+    Print all request that are being sent to sourcekitd as JSON
+    """)
+  public var printRequests: Bool = false
+
   @Option(name: .shortAndLong, help: ArgumentHelp("""
     Divides the work for each file into <total> equal parts \
     and only performs the <page>th group. \
@@ -165,6 +170,7 @@ public struct StressTesterTool: ParsableCommand {
       tempDir: tempDir!,
       astBuildLimit: limit,
       printActions: printActions,
+      printRequests: printRequests,
       requestDurationsOutputFile: requestDurationsOutputFile,
       responseHandler: !reportResponses ? nil :
         { [format] responseData in


### PR DESCRIPTION
This makes it a lot easier to reproduce a SourceKit crash, in particular if you narrowed down the requests that `sk-stress-test` sends to `sourcekitd` using the offset filter.