### PR TITLE
Remove References to SyntaxVerifier That Used UnknownSyntax

### DIFF
--- a/SourceKitStressTester/Sources/Common/Message.swift
+++ b/SourceKitStressTester/Sources/Common/Message.swift
@@ -77,7 +77,7 @@ public enum SourceKitError: Error {
 }
 
 public enum SourceKitErrorReason: String, Codable {
-  case errorResponse, errorTypeInResponse, errorDeserializingSyntaxTree,
+  case errorResponse, errorTypeInResponse,
        sourceAndSyntaxTreeMismatch, missingExpectedResult, errorWritingModule
 }
 
@@ -496,8 +496,6 @@ extension SourceKitErrorReason: CustomStringConvertible {
       return "SourceKit returned an error response"
     case .errorTypeInResponse:
       return "SourceKit returned a response containing <<error type>>"
-    case .errorDeserializingSyntaxTree:
-      return "SourceKit returned a response with invalid SyntaxTree data"
     case .sourceAndSyntaxTreeMismatch:
       return "SourceKit returned a syntax tree that doesn't match the expected source"
     case .missingExpectedResult:

--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -630,19 +630,10 @@ class SourceKitDocument {
       tree = try parseSyntax(request: request)
       executedInstruction = Int(get_current_instruction_count()) - previousInstructionCount
     } catch let error {
-      throw SourceKitError.failed(.errorDeserializingSyntaxTree, request: request, response: error.localizedDescription)
+      throw SourceKitError.failed(.errorResponse, request: request, response: error.localizedDescription)
     }
     self.tree = tree
     self.converter = SourceLocationConverter(file: "", tree: tree)
-
-    /// When we should be able to fully parse the file, we verify the syntax tree
-    if !containsErrors {
-      do {
-        try SyntaxVerifier.verify(Syntax(tree))
-      } catch let error as SyntaxVerifierError {
-        throw SourceKitError.failed(.errorDeserializingSyntaxTree, request: request, response: error.description)
-      }
-    }
 
     if let state = sourceState, state.source != tree.description {
       // FIXME: add state and tree descriptions in their own field


### PR DESCRIPTION
Now that UnknownSyntax is not a thing that the Swift parser ever produces, there's not a reason to keep the SyntaxVerifier around in its current form since that was all it was looking for. Drop it out of the verification pipeline and remove a bogus error case.

Goes with https://github.com/apple/swift-syntax/pull/1131