### PR TITLE
Adjustments for merging `spacedBinaryOperator` and `unspacedBinaryOperator`

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/SwiftSyntaxExtensions.swift
+++ b/SourceKitStressTester/Sources/StressTester/SwiftSyntaxExtensions.swift
@@ -49,7 +49,7 @@ extension SyntaxProtocol {
 extension TokenSyntax {
   var isOperator: Bool {
     switch tokenKind {
-    case .prefixOperator, .postfixOperator, .spacedBinaryOperator, .unspacedBinaryOperator, .equal:
+    case .prefixOperator, .postfixOperator, .binaryOperator, .equal:
       return true
     default:
       return false


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1215