### PR TITLE
Remove errorTokens from `CodeBlockItem`

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
@@ -76,9 +76,7 @@ extension Collection {
       CodeBlockItemSyntax(
         item: try transform($0).replacingTriviaWith(
           leading: statementLeadingTrivia, trailing: statementTrailingTrivia
-        ),
-        semicolon: nil,
-        errorTokens: nil
+        )
       )
     }
     


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1177