### PR TITLE
Adjustment for removed `with<childName>` functions

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
@@ -17,7 +17,7 @@
 import SwiftSyntax
 
 protocol TrailingCommaSyntax: SyntaxProtocol {
-  func withTrailingComma(_ token: TokenSyntax?) -> Self
+  var trailingComma: TokenSyntax? { get set }
 }
 
 extension FunctionParameterSyntax: TrailingCommaSyntax {}
@@ -29,11 +29,11 @@ extension BidirectionalCollection where Element: TrailingCommaSyntax {
 
     for elem in dropLast() {
       let newComma = TokenSyntax.commaToken(trailingTrivia: betweenTrivia)
-      let newElem = elem.withTrailingComma(newComma)
+      let newElem = elem.with(\.trailingComma, newComma)
       elems.append(newElem)
     }
     if let last = last {
-      elems.append(last.withTrailingComma(nil))
+      elems.append(last.with(\.trailingComma, nil))
     }
 
     return elems

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -19,8 +19,7 @@ import SwiftSyntax
 import Foundation
 
 public protocol DeclWithMembers: DeclSyntaxProtocol {
-  var members: MemberDeclBlockSyntax { get }
-  func withMembers(_ newChild: MemberDeclBlockSyntax) -> Self
+  var members: MemberDeclBlockSyntax { get set }
 }
 
 extension ClassDeclSyntax: DeclWithMembers {}
@@ -32,24 +31,23 @@ extension ExtensionDeclSyntax: DeclWithMembers {}
 public protocol DeclWithParameters: DeclSyntaxProtocol {
   var baseName: String { get }
   
-  var parameters: ParameterClauseSyntax { get }
-  func withParameters(_ parameters: ParameterClauseSyntax) -> Self
+  var parameters: ParameterClauseSyntax { get set }
 }
 
 public protocol AbstractFunctionDecl: DeclWithParameters {
-  var body: CodeBlockSyntax? { get }
-  func withBody(_ body: CodeBlockSyntax?) -> Self
+  var body: CodeBlockSyntax? { get set }
 }
 
 extension InitializerDeclSyntax: AbstractFunctionDecl {
   public var baseName: String { return "init" }
 
   public var parameters: ParameterClauseSyntax {
-    return signature.input
-  }
-
-  public func withParameters(_ parameters: ParameterClauseSyntax) -> InitializerDeclSyntax {
-    return withSignature(signature.withInput(parameters))
+    get {
+      return signature.input
+    }
+    set {
+      self = with(\.signature, signature.with(\.input, newValue))
+    }
   }
 }
 
@@ -59,11 +57,12 @@ extension FunctionDeclSyntax: AbstractFunctionDecl {
   }
 
   public var parameters: ParameterClauseSyntax {
-    return signature.input
-  }
-
-  public func withParameters(_ parameters: ParameterClauseSyntax) -> FunctionDeclSyntax {
-    return withSignature(signature.withInput(parameters))
+    get {
+      return signature.input
+    }
+    set {
+      self = with(\.signature, signature.with(\.input, newValue))
+    }
   }
 }
 
@@ -71,11 +70,12 @@ extension SubscriptDeclSyntax: DeclWithParameters {
   public var baseName: String { return "subscript" }
 
   public var parameters: ParameterClauseSyntax {
-    return indices
-  }
-
-  public func withParameters(_ parameters: ParameterClauseSyntax) -> SubscriptDeclSyntax {
-    return withIndices(parameters)
+    get {
+      return indices
+    }
+    set {
+      self = with(\.indices, newValue)
+    }
   }
 }
 

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxTriviaExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxTriviaExtensions.swift
@@ -29,11 +29,11 @@ extension SyntaxProtocol {
       withoutActuallyEscaping(leading) { leading in
         SingleTokenRewriter(
           shouldRewrite: { $0 == ($0.parent?.children(viewMode: .sourceAccurate).last ?? $0) },
-          transform: { $0.withTrailingTrivia(trailing($0.trailingTrivia)) }
+          transform: { $0.with(\.trailingTrivia, trailing($0.trailingTrivia)) }
         ).visit(
           SingleTokenRewriter(
             shouldRewrite: { $0 == ($0.parent?.children(viewMode: .sourceAccurate).first ?? $0) },
-            transform: { $0.withLeadingTrivia(leading($0.leadingTrivia)) }
+            transform: { $0.with(\.leadingTrivia, leading($0.leadingTrivia)) }
           ).visit(Syntax(self))
         ).as(Self.self)!
       }


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1253