### PR TITLE
[5.8] Adjustments because SwiftSyntax cherry-picks most API changes from main to release/5.8

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -613,7 +613,7 @@ private class ActionTokenCollector: SyntaxAnyVisitor {
     if !token.isOperator && token.ancestors.contains(where: {($0.isProtocol(ExprSyntaxProtocol.self) || $0.isProtocol(TypeSyntaxProtocol.self)) && $0.firstToken == token}) {
       return [.format, .codeComplete, .typeContextInfo, .conformingMethodList]
     }
-    if case .contextualKeyword(let text) = token.tokenKind, ["get", "set", "didSet", "willSet"].contains(text) {
+    if case .contextualKeyword(let keyword) = token.tokenKind, [.get, .set, .didSet, .willSet].contains(keyword) {
       return [.format, .codeComplete, .typeContextInfo, .conformingMethodList]
     }
     return [.format]
@@ -626,7 +626,7 @@ private class ActionTokenCollector: SyntaxAnyVisitor {
     if !token.isOperator && token.ancestors.contains(where: {($0.isProtocol(ExprSyntaxProtocol.self) || $0.isProtocol(TypeSyntaxProtocol.self)) && $0.lastToken == token}) {
       return [.codeComplete, .typeContextInfo, .conformingMethodList]
     }
-    if case .contextualKeyword(let text) = token.tokenKind, ["get", "set", "didSet", "willSet"].contains(text) {
+    if case .contextualKeyword(let keyword) = token.tokenKind, [.get, .set, .didSet, .willSet].contains(keyword) {
       return [.codeComplete, .typeContextInfo, .conformingMethodList]
     }
     return []

--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -613,7 +613,7 @@ private class ActionTokenCollector: SyntaxAnyVisitor {
     if !token.isOperator && token.ancestors.contains(where: {($0.isProtocol(ExprSyntaxProtocol.self) || $0.isProtocol(TypeSyntaxProtocol.self)) && $0.firstToken == token}) {
       return [.format, .codeComplete, .typeContextInfo, .conformingMethodList]
     }
-    if case .contextualKeyword(let keyword) = token.tokenKind, [.get, .set, .didSet, .willSet].contains(keyword) {
+    if case .keyword(let keyword) = token.tokenKind, [.get, .set, .didSet, .willSet].contains(keyword) {
       return [.format, .codeComplete, .typeContextInfo, .conformingMethodList]
     }
     return [.format]
@@ -626,7 +626,7 @@ private class ActionTokenCollector: SyntaxAnyVisitor {
     if !token.isOperator && token.ancestors.contains(where: {($0.isProtocol(ExprSyntaxProtocol.self) || $0.isProtocol(TypeSyntaxProtocol.self)) && $0.lastToken == token}) {
       return [.codeComplete, .typeContextInfo, .conformingMethodList]
     }
-    if case .contextualKeyword(let keyword) = token.tokenKind, [.get, .set, .didSet, .willSet].contains(keyword) {
+    if case .keyword(let keyword) = token.tokenKind, [.get, .set, .didSet, .willSet].contains(keyword) {
       return [.codeComplete, .typeContextInfo, .conformingMethodList]
     }
     return []

--- a/SourceKitStressTester/Sources/StressTester/SwiftSyntaxExtensions.swift
+++ b/SourceKitStressTester/Sources/StressTester/SwiftSyntaxExtensions.swift
@@ -49,7 +49,7 @@ extension SyntaxProtocol {
 extension TokenSyntax {
   var isOperator: Bool {
     switch tokenKind {
-    case .prefixOperator, .postfixOperator, .spacedBinaryOperator, .unspacedBinaryOperator, .equal:
+    case .prefixOperator, .postfixOperator, .binaryOperator, .equal:
       return true
     default:
       return false

--- a/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
@@ -288,17 +288,6 @@ extension PatternSyntax {
     case .identifierPattern(let identifierPattern):
       return [(identifierPattern.identifier, nil)]
 
-    case .asTypePattern(let asTypePattern):
-      let subnames = asTypePattern.pattern.boundIdentifiers
-      if let tupleType = asTypePattern.type.as(TupleTypeSyntax.self) {
-        return zip(subnames.map { $0.name }, tupleType.elements.map { $0.type })
-          .map { ($0.0, $0.1) }
-      }
-      else {
-        assert(subnames.count == 1)
-        return [ (subnames[0].name, asTypePattern.type) ]
-      }
-
     case .tuplePattern(let tuplePattern):
       return tuplePattern.elements.flatMap { $0.pattern.boundIdentifiers }
 

--- a/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
@@ -458,11 +458,9 @@ extension Optional where Wrapped == AttributeListSyntax {
   func contains(named name: String) -> Bool {
     return self?.contains { 
       if let builtinAttribute = $0.as(AttributeSyntax.self) {
-        return builtinAttribute.attributeName.text == name 
-      } else if let customAttribute = $0.as(CustomAttributeSyntax.self) {
         // FIXME: Attribute name is a TypeSyntax, so .description isn't quite
         // right here (e.g. @MyCustomAttribute<MyTypeParam> is valid)
-        return customAttribute.attributeName.description == name
+        return builtinAttribute.attributeName.description == name
       } else {
         preconditionFailure("unhandled AttributeListSyntax element kind")
       }

--- a/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
@@ -312,11 +312,7 @@ extension SynthesizeMemberwiseInitializerEvolution {
         return .expr(expr)
       }
 
-      let signature = FunctionSignatureSyntax(
-        input: parameters,
-        asyncOrReasyncKeyword: nil,
-        throwsOrRethrowsKeyword: nil,
-        output: nil)
+      let signature = FunctionSignatureSyntax(input: parameters)
 
       let newInitializer = InitializerDeclSyntax(
         attributes: nil,

--- a/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
@@ -321,7 +321,7 @@ extension SynthesizeMemberwiseInitializerEvolution {
       let newInitializer = InitializerDeclSyntax(
         attributes: nil,
         modifiers: nil,
-        initKeyword: .initKeyword(
+        initKeyword: .keyword(.`init`,
           leadingTrivia: [
             .newlines(2),
             .lineComment("// Synthesized by SynthesizeMemberwiseInitializerEvolution"),

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
@@ -76,9 +76,7 @@ extension Collection {
       CodeBlockItemSyntax(
         item: try transform($0).replacingTriviaWith(
           leading: statementLeadingTrivia, trailing: statementTrailingTrivia
-        ),
-        semicolon: nil,
-        errorTokens: nil
+        )
       )
     }
     

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxConstructionExtensions.swift
@@ -17,7 +17,7 @@
 import SwiftSyntax
 
 protocol TrailingCommaSyntax: SyntaxProtocol {
-  func withTrailingComma(_ token: TokenSyntax?) -> Self
+  var trailingComma: TokenSyntax? { get set }
 }
 
 extension FunctionParameterSyntax: TrailingCommaSyntax {}
@@ -29,11 +29,11 @@ extension BidirectionalCollection where Element: TrailingCommaSyntax {
 
     for elem in dropLast() {
       let newComma = TokenSyntax.commaToken(trailingTrivia: betweenTrivia)
-      let newElem = elem.withTrailingComma(newComma)
+      let newElem = elem.with(\.trailingComma, newComma)
       elems.append(newElem)
     }
     if let last = last {
-      elems.append(last.withTrailingComma(nil))
+      elems.append(last.with(\.trailingComma, nil))
     }
 
     return elems

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -185,9 +185,9 @@ extension TypeSyntax {
 
 extension TokenKind {
   var needsSpace: Bool {
-    if isKeyword { return true }
+    if isLexerClassifiedKeyword { return true }
     switch self {
-    case .identifier, .dollarIdentifier, .integerLiteral, .floatingLiteral, .yield:
+    case .identifier, .dollarIdentifier, .integerLiteral, .floatingLiteral, .keyword(.yield):
       return true
     default:
       return false

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -20,7 +20,7 @@ import Foundation
 
 public protocol DeclWithMembers: DeclSyntaxProtocol {
   var members: MemberDeclBlockSyntax { get }
-  func withMembers(_ newChild: MemberDeclBlockSyntax?) -> Self
+  func withMembers(_ newChild: MemberDeclBlockSyntax) -> Self
 }
 
 extension ClassDeclSyntax: DeclWithMembers {}
@@ -33,7 +33,7 @@ public protocol DeclWithParameters: DeclSyntaxProtocol {
   var baseName: String { get }
   
   var parameters: ParameterClauseSyntax { get }
-  func withParameters(_ parameters: ParameterClauseSyntax?) -> Self
+  func withParameters(_ parameters: ParameterClauseSyntax) -> Self
 }
 
 public protocol AbstractFunctionDecl: DeclWithParameters {
@@ -48,7 +48,7 @@ extension InitializerDeclSyntax: AbstractFunctionDecl {
     return signature.input
   }
 
-  public func withParameters(_ parameters: ParameterClauseSyntax?) -> InitializerDeclSyntax {
+  public func withParameters(_ parameters: ParameterClauseSyntax) -> InitializerDeclSyntax {
     return withSignature(signature.withInput(parameters))
   }
 }
@@ -62,7 +62,7 @@ extension FunctionDeclSyntax: AbstractFunctionDecl {
     return signature.input
   }
 
-  public func withParameters(_ parameters: ParameterClauseSyntax?) -> FunctionDeclSyntax {
+  public func withParameters(_ parameters: ParameterClauseSyntax) -> FunctionDeclSyntax {
     return withSignature(signature.withInput(parameters))
   }
 }
@@ -74,7 +74,7 @@ extension SubscriptDeclSyntax: DeclWithParameters {
     return indices
   }
 
-  public func withParameters(_ parameters: ParameterClauseSyntax?) -> SubscriptDeclSyntax {
+  public func withParameters(_ parameters: ParameterClauseSyntax) -> SubscriptDeclSyntax {
     return withIndices(parameters)
   }
 }

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -19,8 +19,7 @@ import SwiftSyntax
 import Foundation
 
 public protocol DeclWithMembers: DeclSyntaxProtocol {
-  var members: MemberDeclBlockSyntax { get }
-  func withMembers(_ newChild: MemberDeclBlockSyntax) -> Self
+  var members: MemberDeclBlockSyntax { get set }
 }
 
 extension ClassDeclSyntax: DeclWithMembers {}
@@ -32,24 +31,23 @@ extension ExtensionDeclSyntax: DeclWithMembers {}
 public protocol DeclWithParameters: DeclSyntaxProtocol {
   var baseName: String { get }
   
-  var parameters: ParameterClauseSyntax { get }
-  func withParameters(_ parameters: ParameterClauseSyntax) -> Self
+  var parameters: ParameterClauseSyntax { get set }
 }
 
 public protocol AbstractFunctionDecl: DeclWithParameters {
-  var body: CodeBlockSyntax? { get }
-  func withBody(_ body: CodeBlockSyntax?) -> Self
+  var body: CodeBlockSyntax? { get set }
 }
 
 extension InitializerDeclSyntax: AbstractFunctionDecl {
   public var baseName: String { return "init" }
 
   public var parameters: ParameterClauseSyntax {
-    return signature.input
-  }
-
-  public func withParameters(_ parameters: ParameterClauseSyntax) -> InitializerDeclSyntax {
-    return withSignature(signature.withInput(parameters))
+    get {
+      return signature.input
+    }
+    set {
+      self = with(\.signature, signature.with(\.input, newValue))
+    }
   }
 }
 
@@ -59,11 +57,12 @@ extension FunctionDeclSyntax: AbstractFunctionDecl {
   }
 
   public var parameters: ParameterClauseSyntax {
-    return signature.input
-  }
-
-  public func withParameters(_ parameters: ParameterClauseSyntax) -> FunctionDeclSyntax {
-    return withSignature(signature.withInput(parameters))
+    get {
+      return signature.input
+    }
+    set {
+      self = with(\.signature, signature.with(\.input, newValue))
+    }
   }
 }
 
@@ -71,11 +70,12 @@ extension SubscriptDeclSyntax: DeclWithParameters {
   public var baseName: String { return "subscript" }
 
   public var parameters: ParameterClauseSyntax {
-    return indices
-  }
-
-  public func withParameters(_ parameters: ParameterClauseSyntax) -> SubscriptDeclSyntax {
-    return withIndices(parameters)
+    get {
+      return indices
+    }
+    set {
+      self = with(\.indices, newValue)
+    }
   }
 }
 

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxTriviaExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxTriviaExtensions.swift
@@ -29,11 +29,11 @@ extension SyntaxProtocol {
       withoutActuallyEscaping(leading) { leading in
         SingleTokenRewriter(
           shouldRewrite: { $0 == ($0.parent?.children(viewMode: .sourceAccurate).last ?? $0) },
-          transform: { $0.withTrailingTrivia(trailing($0.trailingTrivia)) }
+          transform: { $0.with(\.trailingTrivia, trailing($0.trailingTrivia)) }
         ).visit(
           SingleTokenRewriter(
             shouldRewrite: { $0 == ($0.parent?.children(viewMode: .sourceAccurate).first ?? $0) },
-            transform: { $0.withLeadingTrivia(leading($0.leadingTrivia)) }
+            transform: { $0.with(\.leadingTrivia, leading($0.leadingTrivia)) }
           ).visit(Syntax(self))
         ).as(Self.self)!
       }


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1285.

This cherry-picks the following PRs to `release/5.8` to update this repo for the SwiftSyntax API changes cherry-picked to `release/5.8` by https://github.com/apple/swift-syntax/pull/1285:
- https://github.com/apple/swift-stress-tester/pull/218
- https://github.com/apple/swift-stress-tester/pull/219
- https://github.com/apple/swift-stress-tester/pull/220
- https://github.com/apple/swift-stress-tester/pull/221
- https://github.com/apple/swift-stress-tester/pull/222
- https://github.com/apple/swift-stress-tester/pull/223
- https://github.com/apple/swift-stress-tester/pull/224
- https://github.com/apple/swift-stress-tester/pull/225