### PR TITLE
Adjustments to split `FunctionParameterSyntax` into multiple nodes for function parameters, closure parameters and enum parameters

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -82,7 +82,7 @@ extension SubscriptDeclSyntax: DeclWithParameters {
 extension DeclWithParameters {
   public var name: String {
     let parameterNames = parameters.parameterList.map { param in
-      "\(param.firstName?.text ?? "_"):"
+      "\(param.firstName.text):"
     }
     return "\( baseName )(\( parameterNames.joined() ))"
   }


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1455