### PR TITLE
Remove usage of methods that shouldn’t be part of SwiftSyntax’s public API

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -495,7 +495,9 @@ private struct ActionToken {
       case .functionCallExpr: fallthrough
       case .subscriptExpr: fallthrough
       case .expressionSegment:
-        guard tupleElem.indexInParent != 0 else { return nil }
+        if tupleElem.parent?.as(TupleExprElementListSyntax.self)?.first == tupleElem {
+          return nil
+        }
         return ExpectedResult(name: SwiftName(base: token.textWithoutBackticks + ":", labels: []), kind: .reference)
       default:
         return nil

--- a/SwiftEvolve/Sources/SwiftEvolve/Evolver.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolver.swift
@@ -18,12 +18,12 @@ import Foundation
 import SwiftSyntax
 
 struct Context {
-  var syntaxPath: [Int] = []
+  var syntaxPath: [String] = []
   var declContext = DeclContext()
 
   @discardableResult
   mutating func enter(_ node: Syntax) -> Bool {
-    syntaxPath.append(node.indexInParent)
+    syntaxPath.append(String(describing: node.keyPathInParent!))
     if let node = node.as(Decl.self) {
       declContext.append(node)
       return true
@@ -43,7 +43,7 @@ struct Context {
 }
 
 public class Evolver: SyntaxRewriter {
-  var plan: [URL: [[Int]: [PlannedEvolution]]]
+  var plan: [URL: [[String]: [PlannedEvolution]]]
   var url: URL!
   
   var context = Context()

--- a/SwiftEvolve/Sources/SwiftEvolve/Planner.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Planner.swift
@@ -21,7 +21,7 @@ import SwiftSyntax
 public struct PlannedEvolution: Codable {
   var sourceLocation: String
   var file: URL
-  var syntaxPath: [Int]
+  var syntaxPath: [String]
   var evolution: AnyEvolution
 }
 

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -185,9 +185,8 @@ extension TypeSyntax {
 
 extension TokenKind {
   var needsSpace: Bool {
-    if isLexerClassifiedKeyword { return true }
     switch self {
-    case .identifier, .dollarIdentifier, .integerLiteral, .floatingLiteral, .keyword(.yield):
+    case .identifier, .dollarIdentifier, .integerLiteral, .floatingLiteral, .keyword:
       return true
     default:
       return false


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1482