### PR TITLE
Adjustment for SwiftSyntax rename `members` -> `memberBlock`

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
@@ -171,7 +171,7 @@ public extension Decl {
 
 public extension Decl where Self: DeclWithMembers {
   func lookupDirect(_ name: String) -> Decl? {
-    for item in members.members {
+    for item in memberBlock.members {
       guard let member = item.decl.as(Decl.self) else { continue }
       if member.name == name {
         return member

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -19,7 +19,7 @@ import SwiftSyntax
 import Foundation
 
 public protocol DeclWithMembers: DeclSyntaxProtocol {
-  var members: MemberDeclBlockSyntax { get set }
+  var memberBlock: MemberDeclBlockSyntax { get set }
 }
 
 extension ClassDeclSyntax: DeclWithMembers {}

--- a/SwiftEvolve/Tests/SwiftEvolveTests/RegressionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/RegressionTests.swift
@@ -64,7 +64,7 @@ class RegressionTests: XCTestCase {
 
         XCTAssertThrowsError(
           try SynthesizeMemberwiseInitializerEvolution(
-            for: Syntax(decl.members.members), in: dc, using: &unusedRNG
+            for: Syntax(decl.memberBlock.members), in: dc, using: &unusedRNG
           ),
           "Should throw when a stored property is in a #if block"
         )
@@ -99,7 +99,7 @@ class RegressionTests: XCTestCase {
 
         XCTAssertNoThrow(
           try SynthesizeMemberwiseInitializerEvolution(
-            for: Syntax(decl.members.members), in: dc, using: &unusedRNG
+            for: Syntax(decl.memberBlock.members), in: dc, using: &unusedRNG
           ),
           "Should not throw when properties are only non-stored"
         )
@@ -135,7 +135,7 @@ class RegressionTests: XCTestCase {
 
         XCTAssertNoThrow(
           try SynthesizeMemberwiseInitializerEvolution(
-            for: Syntax(decl.members.members), in: dc, using: &unusedRNG
+            for: Syntax(decl.memberBlock.members), in: dc, using: &unusedRNG
           ),
           "Should not throw when there's an explicit init"
         )

--- a/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleMembersEvolutionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleMembersEvolutionTests.swift
@@ -19,7 +19,7 @@ class ShuffleMembersEvolutionTests: XCTestCase {
     let decl = code.filter(whereIs: EnumDeclSyntax.self).first!
     let dc = DeclContext(declarationChain: [code, decl])
     let evo = try ShuffleMembersEvolution(
-      for: Syntax(decl.members.members), in: dc, using: &predictableRNG
+      for: Syntax(decl.memberBlock.members), in: dc, using: &predictableRNG
     )
 
     XCTAssertEqual(evo?.mapping.count, 3)


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1524