### PR TITLE
Switch SwiftEvolve from SwiftSyntaxParser to SwiftParser

### DIFF
--- a/SwiftEvolve/Package.swift
+++ b/SwiftEvolve/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         ),
         .target(
             name: "SwiftEvolve",
-            dependencies: ["SwiftToolsSupport-auto", "SwiftSyntax", "SwiftSyntaxParser"],
+            dependencies: ["SwiftToolsSupport-auto", "SwiftSyntax", "SwiftParser"],
             linkerSettings: [.unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", sourcekitSearchPath])]
         ),
         .testTarget(

--- a/SwiftEvolve/Sources/SwiftEvolve/SwiftEvolveTool.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SwiftEvolveTool.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 import SwiftSyntax
-import SwiftSyntaxParser
+import SwiftParser
 import TSCBasic
 
 public class SwiftEvolveTool {
@@ -184,7 +184,7 @@ extension SwiftEvolveTool {
       return preparsed
     }
 
-    let parsed = try SyntaxParser.parse(URL(path))
+    let parsed = Parser.parse(source: try String(contentsOf: URL(path)))
     parsedSourceFiles[path] = parsed
     return parsed
   }

--- a/SwiftEvolve/Tests/SwiftEvolveTests/RegressionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/RegressionTests.swift
@@ -1,16 +1,16 @@
 import XCTest
 import SwiftSyntax
-import SwiftSyntaxParser
+import SwiftParser
 import SwiftEvolve
 
 class RegressionTests: XCTestCase {
   var unusedRNG = UnusedGenerator()
 
-  func testUnshuffledDeclsStayInOrder() throws {
+  func testUnshuffledDeclsStayInOrder() {
     // Checks that we don't mess up the order of declarations we're not trying
     // to shuffle. In particular, if we store the properties in a Set or other
     // unordered collection, we could screw this up.
-    let code = try SyntaxParser.parse(source:
+    let code = Parser.parse(source:
       """
       @_fixed_layout struct X {
         var p0: Int
@@ -44,12 +44,12 @@ class RegressionTests: XCTestCase {
     }
   }
 
-  func testStoredIfConfigBlocksMemberwiseInitSynthesis() throws {
+  func testStoredIfConfigBlocksMemberwiseInitSynthesis() {
     do {
       // FIXME: Crashes when run in Xcode because of a version mismatch between
       // SwiftSyntax and the compiler it uses (specifically, how they represent
       // accessor blocks). Should pass in "env PATH=... swift build".
-      let code = try SyntaxParser.parse(source:
+      let code = Parser.parse(source:
         """
         struct A {
           #if os(iOS)
@@ -84,7 +84,7 @@ class RegressionTests: XCTestCase {
     }
 
     do {
-      let code = try SyntaxParser.parse(source:
+      let code = Parser.parse(source:
         """
         struct B {
           var b1: Int
@@ -119,7 +119,7 @@ class RegressionTests: XCTestCase {
     }
 
     do {
-      let code = try SyntaxParser.parse(source:
+      let code = Parser.parse(source:
         """
         struct C {
           #if os(iOS)

--- a/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleGenericRequirementsEvolutionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleGenericRequirementsEvolutionTests.swift
@@ -1,13 +1,13 @@
 import XCTest
 import SwiftSyntax
-import SwiftSyntaxParser
+import SwiftParser
 import SwiftEvolve
 
 class ShuffleGenericRequirementsEvolutionTests: XCTestCase {
   var predictableRNG = PredictableGenerator(values: 1..<16)
 
   func testEvolution() throws {
-    let code = try SyntaxParser.parse(source:
+    let code = Parser.parse(source:
       """
       func foo<T>(_: T) where T: Hashable, T == Comparable {}
       """
@@ -27,8 +27,8 @@ class ShuffleGenericRequirementsEvolutionTests: XCTestCase {
     //               "T == Comparable , T: Hashable")
   }
 
-  func testBypass() throws {
-    let code = try SyntaxParser.parse(source:
+  func testBypass() {
+    let code = Parser.parse(source:
       """
       func foo<T>(_: T) where T: Hashable, T == Comparable {}
       """

--- a/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleMembersEvolutionTests.swift
+++ b/SwiftEvolve/Tests/SwiftEvolveTests/ShuffleMembersEvolutionTests.swift
@@ -1,13 +1,13 @@
 import XCTest
 import SwiftSyntax
-import SwiftSyntaxParser
+import SwiftParser
 import SwiftEvolve
 
 class ShuffleMembersEvolutionTests: XCTestCase {
   var predictableRNG = PredictableGenerator(values: 0..<16)
 
   func testEnumCases() throws {
-    let code = try SyntaxParser.parse(source:
+    let code = Parser.parse(source:
       """
       enum Foo {
         case a


### PR DESCRIPTION
`SwiftSyntaxParser` has been deprecated for a while, SwiftEvolve should use `SwiftParser` instead.