### PR TITLE
[5.9] Rename the incremental source edit to `IncrementalEdit`

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
+++ b/SourceKitStressTester/Sources/StressTester/SourceKitDocument.swift
@@ -598,7 +598,7 @@ class SourceKitDocument {
     let reparseTransition: IncrementalParseTransition?
     switch request {
     case .editorReplaceText(_, let offset, let length, let text):
-      let edit = SourceEdit(range: ByteSourceRange(offset: offset, length: length), replacementLength: text.utf8.count)
+      let edit = IncrementalEdit(range: ByteSourceRange(offset: offset, length: length), replacementLength: text.utf8.count)
       reparseTransition = IncrementalParseTransition(previousTree: self.tree!, edits: ConcurrentEdits(edit))
     default:
       reparseTransition = nil


### PR DESCRIPTION
* **Explanation**: Small rename to allow `SourceEdit` to be used by refactorings.
* **Risk**: Just a rename, either builds or doesn't.
* **Original PR**:  https://github.com/apple/swift-stress-tester/pull/238