### PR TITLE
Adjustments for node renames in swift-syntax

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -491,9 +491,9 @@ private struct ActionToken {
 
     // Report argument label completions for any arguments other than the first
     if let tupleElem = parent.as(TupleExprElementSyntax.self), tupleElem.label == token {
-      switch tupleElem.parent?.parent?.as(SyntaxEnum.self) {
+      switch tupleElem.parent?.parent?.kind {
       case .functionCallExpr: fallthrough
-      case .subscriptExpr: fallthrough
+      case .subscriptCallExpr: fallthrough
       case .expressionSegment:
         if tupleElem.parent?.as(TupleExprElementListSyntax.self)?.first == tupleElem {
           return nil

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -139,9 +139,9 @@ extension DeclContext {
 extension TypeSyntax {
   func lookup(in context: DeclContext) -> DeclContext? {
     switch Syntax(self).as(SyntaxEnum.self) {
-    case .simpleTypeIdentifier(let simpleTypeIdentifier):
+    case .identifierType(let simpleTypeIdentifier):
       return context.lookupUnqualified(simpleTypeIdentifier.name)
-    case .memberTypeIdentifier(let memberTypeIdentifier):
+    case .memberType(let memberTypeIdentifier):
       return memberTypeIdentifier.baseType.lookup(in: context)?.lookupDirect(memberTypeIdentifier.name)
     default:
       return nil


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1949