### PR TITLE
Adjustments because MemberAccessExpr represents the member name as DeclReferenceExpr

### DIFF
--- a/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
+++ b/SourceKitStressTester/Sources/StressTester/ActionGenerators.swift
@@ -512,15 +512,15 @@ private struct ActionToken {
         let name = SwiftName(base: token.text, labels: callArgs)
         return ExpectedResult(name: name, kind: kind)
       }
-    }
-    if let parent = parent.as(MemberAccessExprSyntax.self), parent.name == token {
-      if let refArgs = parent.declNameArguments {
-        let name = SwiftName(base: token.text, labels: refArgs.arguments.map{ $0.name.text })
-        return ExpectedResult(name: name, kind: .reference)
-      }
-      if let (kind, callArgs) = getParentArgs(of: parent) {
-        let name = SwiftName(base: token.text, labels: callArgs)
-        return ExpectedResult(name: name, kind: kind)
+      if let parentsParent = parent.parent?.as(MemberAccessExprSyntax.self), parentsParent.name == token {
+        if let refArgs = parentsParent.declNameArguments {
+          let name = SwiftName(base: token.text, labels: refArgs.arguments.map{ $0.name.text })
+          return ExpectedResult(name: name, kind: .reference)
+        }
+        if let (kind, callArgs) = getParentArgs(of: parentsParent) {
+          let name = SwiftName(base: token.text, labels: callArgs)
+          return ExpectedResult(name: name, kind: kind)
+        }
       }
     }
     let name = SwiftName(base: token.text, labels: [])

--- a/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
+++ b/SourceKitStressTester/Tests/StressTesterToolTests/ActionGeneratorTests.swift
@@ -188,13 +188,13 @@ class ActionGeneratorTests: XCTestCase {
     }
     XCTAssertEqual(edits, [
         Action.replaceText(offset: 0, length: 9, text: ""),
-        Action.replaceText(offset: 0, length: 0, text: "."), // .
-        Action.replaceText(offset: 1, length: 0, text: "c"), // .c
+        Action.replaceText(offset: 0, length: 0, text: "c"), // c
+        Action.replaceText(offset: 0, length: 0, text: "."), // .c
         Action.replaceText(offset: 0, length: 0, text: "["), // [.c
         Action.replaceText(offset: 3, length: 0, text: "]"), // [.c]
         Action.replaceText(offset: 0, length: 0, text: "a"), // a[.c]
-        Action.replaceText(offset: 1, length: 0, text: "."), // a.[.c]
-        Action.replaceText(offset: 2, length: 0, text: "b"), // a.b[.c]
+        Action.replaceText(offset: 1, length: 0, text: "b"), // ab[.c]
+        Action.replaceText(offset: 1, length: 0, text: "."), // a.b[.c]
         Action.replaceText(offset: 3, length: 0, text: "("), // a.b([.c]
         Action.replaceText(offset: 8, length: 0, text: ")"), // a.b([.c])
     ])


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1950

---

We need to take the extra nesting level into account when detecting a member access based on the identifiers name in ActionGenerators.swift.

The extra nesting level changes the way the inside out rewriter generates edits because the accessed member’s name is now one further nesting level deep.