### PR TITLE
Adjustment for `floatingLiteral` -> `floatLiteral` rename in swift-syntax

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
@@ -332,10 +332,10 @@ extension SynthesizeMemberwiseInitializerEvolution {
         body: body
       )
       
-      return members.appending(MemberBlockItemSyntax(
+      return members + [MemberBlockItemSyntax(
         decl: DeclSyntax(newInitializer),
         semicolon: nil
-      ))
+      )]
     }
     return Syntax(evolved)
   }

--- a/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/SyntaxExtensions.swift
@@ -186,7 +186,7 @@ extension TypeSyntax {
 extension TokenKind {
   var needsSpace: Bool {
     switch self {
-    case .identifier, .dollarIdentifier, .integerLiteral, .floatingLiteral, .keyword:
+    case .identifier, .dollarIdentifier, .integerLiteral, .floatLiteral, .keyword:
       return true
     default:
       return false


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1983