### PR TITLE
Update for the fact that syntax collections are always non-optional in SwiftSyntax now

### DIFF
--- a/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/DeclContext.swift
@@ -155,7 +155,7 @@ public protocol Decl {
   var isResilient: Bool { get }
   var isStored: Bool { get }
 
-  var modifiers: DeclModifierListSyntax? { get }
+  var modifiers: DeclModifierListSyntax { get }
   
   func lookupDirect(_ name: String) -> Decl?
 }
@@ -165,7 +165,7 @@ public extension Decl {
   var isStored: Bool { return false }
 
   var formalAccessLevel: AccessLevel {
-    return modifiers?.lazy.compactMap { $0.accessLevel }.first ?? .internal
+    return modifiers.lazy.compactMap { $0.accessLevel }.first ?? .internal
   }
 }
 
@@ -197,7 +197,7 @@ public extension Decl where Self: AbstractFunctionDecl {
 extension SourceFileSyntax: Decl {
   public var nameString: String { return "(file)" }
 
-  public var modifiers: DeclModifierListSyntax? { return nil }
+  public var modifiers: DeclModifierListSyntax { return [] }
   
   public func lookupDirect(_ name: String) -> Decl? {
     for item in statements {
@@ -450,9 +450,9 @@ extension IfConfigDeclSyntax {
 
 // MARK: - Helpers
 
-extension Optional where Wrapped == AttributeListSyntax {
+extension AttributeListSyntax {
   func contains(named name: String) -> Bool {
-    return self?.contains { 
+    return self.contains {
       if let builtinAttribute = $0.as(AttributeSyntax.self) {
         // FIXME: Attribute name is a TypeSyntax, so .description isn't quite
         // right here (e.g. @MyCustomAttribute<MyTypeParam> is valid)
@@ -460,7 +460,7 @@ extension Optional where Wrapped == AttributeListSyntax {
       } else {
         preconditionFailure("unhandled AttributeListSyntax element kind")
       }
-    } ?? false
+    }
   }
 }
 

--- a/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
+++ b/SwiftEvolve/Sources/SwiftEvolve/Evolution.swift
@@ -293,15 +293,9 @@ extension SynthesizeMemberwiseInitializerEvolution {
     let evolved = inits.reduce(members) { members, properties in
       let parameters = properties.mapToFunctionParameterClause {
         FunctionParameterSyntax(
-          attributes: nil,
-          modifiers: nil,
           firstName: .identifier($0.name),
-          secondName: nil,
           colon: .colonToken(trailingTrivia: [.spaces(1)]),
-          type: TypeSyntax(IdentifierTypeSyntax(name: .identifier($0.type), genericArgumentClause: nil)),
-          ellipsis: nil,
-          defaultValue: nil,
-          trailingComma: nil
+          type: TypeSyntax(IdentifierTypeSyntax(name: .identifier($0.type), genericArgumentClause: nil))
         )
       }
       
@@ -315,8 +309,6 @@ extension SynthesizeMemberwiseInitializerEvolution {
       let signature = FunctionSignatureSyntax(parameterClause: parameters)
 
       let newInitializer = InitializerDeclSyntax(
-        attributes: nil,
-        modifiers: nil,
         initKeyword: .keyword(.`init`,
           leadingTrivia: [
             .newlines(2),
@@ -325,10 +317,7 @@ extension SynthesizeMemberwiseInitializerEvolution {
           ],
           trailingTrivia: []
         ),
-        optionalMark: nil,
-        genericParameterClause: nil,
         signature: signature,
-        genericWhereClause: nil,
         body: body
       )
       


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/2043