### PR TITLE
Pass `--verbose` to `swift build`

### DIFF
--- a/build-script-helper.py
+++ b/build-script-helper.py
@@ -186,6 +186,9 @@ def invoke_swift_single_product(package_dir, swift_exec, action, product, build_
   if multiroot_data_file:
     args.extend(['--multiroot-data-file', multiroot_data_file])
 
+  if verbose:
+    args.append('--verbose')
+
   if action == 'test':
     args.extend(['--test-product', product, '--disable-testable-imports'])
   else:


### PR DESCRIPTION
All other packages that were built with SwiftPM passed `--verbose` but the stress tester did not. This caused swift-syntax to get rebuilt (yes, adding `--verbose` apparently changes the compiler arguemnts and thus causes a complete rebuild).